### PR TITLE
Integrate investment explore UI with API

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,97 @@
+# Investment Explore UI Integration
+
+## Goal
+
+Replace static `investments.json` and hardcoded detail sections with the domain-first `/api/investments` backend.
+
+## Scope
+
+- Types, service, React Query hooks for list + detail bundle.
+- Landing/explore cards, new launches carousel.
+- Detail page composes domain resources (highlights, content-blocks, team, financials, etc.).
+
+## Out Of Scope
+
+- Invest / watchlist / ask-question authenticated actions.
+- Admin listing CRUD.
+
+## API contracts and endpoints available
+
+See `antital-api/PLAN.md`. UI consumes:
+
+- `GET /api/investments`
+- `GET /api/investments/{idOrSlug}` + sub-resources (parallel fetch in one hook)
+
+## Checkpoints
+
+| # | Checkpoint | Status |
+|---|------------|--------|
+| 1 | Types, service, mappers, hooks | completed |
+| 2 | List integration (landing, explore, new launches) | completed |
+| 3 | Detail page + section props from API | completed |
+| 4 | Browser verification (Playwright) | completed |
+
+## Permission rule
+
+Implement checkpoints sequentially; update status when complete.
+
+---
+
+## Checkpoint 1 — Types, service, mappers, hooks
+
+- [x] Status: completed
+
+**Files:** `src/types/investment.ts`, `src/services/investmentService.ts`, `src/lib/investment-mappers.ts`, `src/hooks/use-investments.ts`, `src/hooks/use-investment-detail.ts`, `src/constants.ts`
+
+**Done criteria:** Service calls all public investment routes; hooks expose list + detail bundle.
+
+---
+
+## Checkpoint 2 — List integration
+
+- [x] Status: completed
+
+**UI entry:** Landing `InvestmentOpportunities`, explore page, `NewLaunches`.
+
+**Files:** `investment-opportunities.tsx`, `new-launches.tsx`
+
+**Done criteria:** Cards render from API with loading/error states; links use slug.
+
+**Verified:** Landing at `http://localhost:3000/` shows AgriTech Innovations, AquaPure Innovations, EcoBuild Materials from API.
+
+---
+
+## Checkpoint 3 — Detail page
+
+- [x] Status: completed
+
+**UI entry:** `/explore/[id]`
+
+**Files:** `explore/[id]/page.tsx`, `investment-detail-page-client.tsx`, `investment-detail-page-content.tsx`, investment section components
+
+**Done criteria:** Page fetches shell + sub-resources; no hardcoded NEXUS AI copy; UI composes domain data.
+
+**Verified:** `/explore/greentech-solutions` renders GreenTech Solutions with API highlights, team, financials, deal terms, and funding panel.
+
+---
+
+## Checkpoint 4 — Browser verification
+
+- [x] Status: completed
+
+**Done criteria:** Landing shows API cards; detail page for `greentech-solutions` shows GreenTech data from API.
+
+**Test notes (Playwright, 2026-05-31):**
+
+- Landing cards load after React Query fetch (no static JSON).
+- Detail overview: problem statement, ₦675M ARR highlight, proprietary edge, market traction, TL;DR.
+- Detail tab: Dr. Eleanor Vance / Alex Chen team, financial metrics table, use of proceeds, risks, documents.
+- Investment panel: ₦7,381,254 raised, 341 investors, target rating 4.5.
+- Minor: seed media thumbnails (`/investments/thumb*.jpg`) 404 in Next image optimizer — assets not in `public/` yet.
+
+## Readiness checklist
+
+- [x] API running with investment routes (`https://localhost:7008`)
+- [x] UI `NEXT_PUBLIC_API_URL` points at API
+- [x] GreenTech full detail seeded on backend
+- [ ] Optional follow-up: add thumbnail assets to `public/investments/` or update seed URLs

--- a/src/app/(marketing)/explore/[id]/investment-detail-page-client.tsx
+++ b/src/app/(marketing)/explore/[id]/investment-detail-page-client.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { notFound } from 'next/navigation'
+import { InvestmentDetailPageContent } from './investment-detail-page-content'
+import { useInvestmentDetail } from '@/hooks/use-investment-detail'
+
+interface InvestmentDetailPageClientProps {
+  idOrSlug: string
+}
+
+export function InvestmentDetailPageClient({ idOrSlug }: InvestmentDetailPageClientProps) {
+  const { data, isLoading, isError } = useInvestmentDetail(idOrSlug)
+
+  if (isLoading) {
+    return (
+      <div className="w-full max-w-[1440px] mx-auto px-4 py-24 text-center text-muted-foreground font-dm-sans">
+        Loading investment details...
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    notFound()
+  }
+
+  return <InvestmentDetailPageContent detail={data} />
+}

--- a/src/app/(marketing)/explore/[id]/investment-detail-page-content.tsx
+++ b/src/app/(marketing)/explore/[id]/investment-detail-page-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
-import { InvestmentCardData } from '@/components/investment/organisms/investment-card'
+import React, { useState, useEffect, useLayoutEffect, useRef, useMemo } from 'react'
 import { VideoSection } from '@/components/investment/organisms/video-section'
 import { InvestmentPanel } from '@/components/investment/organisms/investment-panel'
 import { DealTermsSection } from '@/components/investment/organisms/deal-terms-section'
@@ -22,96 +21,119 @@ import { UpdatesSection } from '@/components/investment/organisms/updates-sectio
 import { AskQuestionSection } from '@/components/investment/organisms/ask-question-section'
 import { MediaThumbnails } from '@/components/investment/molecules/media-thumbnails'
 import { TestimonialsSection } from '@/components/investment/organisms/testimonials-section'
+import type { InvestmentDetailBundle } from '@/types/investment'
+import {
+  findContentBlockByKey,
+  findContentBlockByType,
+  getMediaThumbnails,
+  getVideoUrl,
+  mapBlockItems,
+  splitHighlights,
+} from '@/lib/investment-mappers'
 
 interface InvestmentDetailPageContentProps {
-  investment: InvestmentCardData
+  detail: InvestmentDetailBundle
 }
 
-/**
- * Check if an element or its parents are scrollable.
- * Recursively traverses the DOM tree and performs DOM queries (getComputedStyle, scrollHeight, clientHeight)
- * on each element. This is a pure utility function moved outside the component to avoid function
- * recreation on every render, but it is not memoized - it performs fresh DOM queries on every call.
- */
 function isScrollableElement(element: Element | null): boolean {
   if (!element || element === document.body || element === document.documentElement) {
     return false
   }
-  
+
   const style = window.getComputedStyle(element)
   const overflowY = style.overflowY
   const hasScrollableContent = element.scrollHeight > element.clientHeight
-  
+
   return (
     (overflowY === 'scroll' || overflowY === 'auto') &&
     hasScrollableContent
   ) || isScrollableElement(element.parentElement)
 }
 
-/**
- * Detect if the current device is iOS.
- * This is a static device property that won't change during the session,
- * so it's computed once at module load time.
- */
 const IS_IOS = typeof window !== 'undefined' && (
   /iPad|iPhone|iPod/.test(navigator.userAgent) ||
   (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
 )
 
-export function InvestmentDetailPageContent({ investment }: InvestmentDetailPageContentProps) {
-  // Investment data is available but not currently used - will be used for dynamic content later
-  void investment
+export function InvestmentDetailPageContent({ detail }: InvestmentDetailPageContentProps) {
+  const { shell, highlights, contentBlocks, team, financials, risks, documents, media, updates, testimonials } = detail
+  const { offering, funding, dealTerms, corporateProfile } = shell
+
+  const { stats: statCards, bullets } = useMemo(() => splitHighlights(highlights), [highlights])
+
+  const problemBlock = useMemo(
+    () => findContentBlockByType(contentBlocks, 'ProblemStatement'),
+    [contentBlocks]
+  )
+  const proprietaryEdgeBlock = useMemo(
+    () => findContentBlockByKey(contentBlocks, 'proprietary-edge'),
+    [contentBlocks]
+  )
+  const marketTractionBlock = useMemo(
+    () => findContentBlockByKey(contentBlocks, 'market-traction'),
+    [contentBlocks]
+  )
+  const tldrBlock = useMemo(
+    () => findContentBlockByType(contentBlocks, 'Tldr'),
+    [contentBlocks]
+  )
+  const useOfProceedsIntroBlock = useMemo(
+    () => findContentBlockByKey(contentBlocks, 'use-of-proceeds-intro'),
+    [contentBlocks]
+  )
+
+  const thumbnails = useMemo(() => getMediaThumbnails(media), [media])
+  const videoUrl = useMemo(() => getVideoUrl(media), [media])
+
+  const galleryImages = useMemo(
+    () =>
+      media
+        .filter((m) => m.assetType.toLowerCase() === 'image')
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+        .map((m) => m.url),
+    [media]
+  )
+
   const [activeTab, setActiveTab] = useState('overview')
   const [stickyButtonHeight, setStickyButtonHeight] = useState(0)
   const stickyButtonRef = useRef<HTMLDivElement>(null)
-  
-  // Prevent iOS overscroll bounce (CSS overscroll-behavior doesn't work reliably on iOS Safari)
-  // Only apply JavaScript fallback on iOS devices to avoid performance impact on other platforms
   const lastTouchYRef = useRef(0)
-  
+
   useEffect(() => {
-    // Skip JavaScript handler on non-iOS devices - rely on CSS overscroll-behavior
     if (!IS_IOS) {
       return
     }
-    
+
     const preventOverscroll = (e: TouchEvent) => {
       const touch = e.touches[0] || e.changedTouches[0]
       if (!touch) return
-      
-      // Early exit: Don't prevent scroll if user is interacting with a scrollable child element
+
       const target = e.target as Element
       if (target && isScrollableElement(target)) {
         return
       }
-      
+
       const scrollTop = window.pageYOffset || document.documentElement.scrollTop
       const scrollHeight = document.documentElement.scrollHeight
       const clientHeight = document.documentElement.clientHeight
-      
-      // Early exit if not at boundaries (most common case)
+
       const threshold = 5
       const isAtTop = scrollTop <= threshold
       const isAtBottom = scrollTop + clientHeight >= scrollHeight - threshold
-      
+
       if (!isAtTop && !isAtBottom) {
-        // Not at boundary, allow normal scroll - update lastTouchY and return
         lastTouchYRef.current = touch.clientY
         return
       }
-      
-      // Only calculate delta if we're at a boundary
+
       const touchDeltaY = touch.clientY - lastTouchYRef.current
-      
-      // At top and trying to scroll up - prevent overscroll
+
       if (isAtTop && touchDeltaY > 0) {
         e.preventDefault()
-      }
-      // At bottom and trying to scroll down - prevent overscroll
-      else if (isAtBottom && touchDeltaY < 0) {
+      } else if (isAtBottom && touchDeltaY < 0) {
         e.preventDefault()
       }
-      
+
       lastTouchYRef.current = touch.clientY
     }
 
@@ -120,215 +142,203 @@ export function InvestmentDetailPageContent({ investment }: InvestmentDetailPage
         lastTouchYRef.current = e.touches[0].clientY
       }
     }
-    
-    // Use passive listeners where possible to improve scroll performance
+
     document.addEventListener('touchstart', handleTouchStart, { passive: true })
-    // touchmove must be non-passive to allow preventDefault, but we minimize its impact
     document.addEventListener('touchmove', preventOverscroll, { passive: false })
-    
+
     return () => {
       document.removeEventListener('touchstart', handleTouchStart)
       document.removeEventListener('touchmove', preventOverscroll)
     }
   }, [])
-  
-  // Dynamically calculate sticky button height for mobile padding
-  // Use useLayoutEffect to ensure refs are available synchronously after DOM mutations
+
   useLayoutEffect(() => {
-    // Capture ref value at effect execution time for cleanup
     const buttonElement = stickyButtonRef.current
-    
+
     const updateStickyButtonHeight = () => {
       const currentElement = stickyButtonRef.current
       if (currentElement) {
-        const height = currentElement.offsetHeight
-        setStickyButtonHeight(height)
+        setStickyButtonHeight(currentElement.offsetHeight)
       } else {
-        // Reset height when button is not visible (e.g., on questions tab)
         setStickyButtonHeight(0)
       }
     }
 
-    // Initial measurement - refs are guaranteed to be available in useLayoutEffect
     updateStickyButtonHeight()
-
-    // Update on window resize
     window.addEventListener('resize', updateStickyButtonHeight)
-    
-    // Use ResizeObserver for more accurate measurements when element is available
+
     let resizeObserver: ResizeObserver | null = null
     let observedElement: Element | null = null
-    
+
     if (typeof ResizeObserver !== 'undefined' && buttonElement) {
-      // Ref is available synchronously in useLayoutEffect, so we can set up observer immediately
       observedElement = buttonElement
       resizeObserver = new ResizeObserver(updateStickyButtonHeight)
       resizeObserver.observe(buttonElement)
     }
 
-    // Cleanup function
     return () => {
-      // Remove event listeners
       window.removeEventListener('resize', updateStickyButtonHeight)
-      
-      // Clean up ResizeObserver if it was created
-      // Use observedElement (captured when observer was created) or buttonElement (captured at effect start)
       const elementToUnobserve = observedElement || buttonElement
       if (resizeObserver && elementToUnobserve) {
         resizeObserver.unobserve(elementToUnobserve)
         resizeObserver.disconnect()
       }
     }
-  }, [activeTab]) // Re-measure when tab changes (button visibility changes)
-  
-  // Hardcoded data for now - will refactor later
-  const daysLeft = 14
-  const problemTitle = 'The Problem We Solve: Addressing Market Inefficiency'
-  const problemDescription = 'Current small and medium-sized enterprises (SMEs) struggle with a complex, fragmented supply chain management system, leading to an average 15% loss in operational efficiency and increased waste. Existing solutions are often too expensive for smaller players or lack the necessary AI-driven predictive capabilities. NEXUS AI is changing this. We provide an accessible, cloud-based platform that uses proprietary machine learning models to forecast inventory needs and optimize logistics routes with 98.5% accuracy, a significant leap over the industry standard of 85%.'
+  }, [activeTab])
+
+  const daysLeft = offering.daysLeft ?? 0
 
   return (
-    <div 
+    <div
       className="w-full lg:pb-0"
       style={{
         paddingBottom: stickyButtonHeight > 0 ? `${stickyButtonHeight}px` : '0px',
       }}
     >
-        <div className="w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-12 xl:px-[104px] py-8 lg:py-16">
-          {/* First Section - Days Left Badge and Problem Section */}
-          <section className="relative w-full">
-            <DaysLeftBadge daysLeft={daysLeft} />
-            <ProblemSection title={problemTitle} description={problemDescription} />
-          </section>
+      <div className="w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-12 xl:px-[104px] py-8 lg:py-16">
+        <section className="relative w-full">
+          {daysLeft > 0 && <DaysLeftBadge daysLeft={daysLeft} />}
+          {problemBlock && (
+            <ProblemSection
+              title={problemBlock.title ?? 'The Problem We Solve'}
+              description={problemBlock.summary ?? ''}
+            />
+          )}
+        </section>
 
-          {/* Two Column Section - Video and Investment Panel */}
-          <section className="w-full mt-16">
-            <div className="flex flex-col lg:flex-row gap-8 w-full items-start">
-              {/* Left Column */}
-              <div className="flex flex-col w-full lg:w-auto lg:flex-1" style={{ maxWidth: '816px' }}>
-                <VideoSection />
-                
-                {/* Media Thumbnails and Like/Share */}
+        <section className="w-full mt-16">
+          <div className="flex flex-col lg:flex-row gap-8 w-full items-start">
+            <div className="flex flex-col w-full lg:w-auto lg:flex-1" style={{ maxWidth: '816px' }}>
+              <VideoSection videoUrl={videoUrl} coverImageUrl={offering.coverImageUrl} />
+
+              {(thumbnails.length > 0 || media.length > 0) && (
                 <div className="w-full mt-4">
-                  <MediaThumbnails />
+                  <MediaThumbnails
+                    thumbnails={
+                      thumbnails.length > 0
+                        ? thumbnails
+                        : [offering.coverImageUrl]
+                    }
+                  />
                 </div>
-                
-                {/* Left Side Content Below Video */}
-                <div className="flex flex-col gap-12 w-full mt-16">
-                  {/* Main Heading - Company Name */}
-                  <h1
-                    className="text-[#042E27] dark:text-[#A7B832]"
-                    style={{
-                      fontFamily: 'var(--font-rethink-sans)',
-                      fontWeight: 700,
-                      fontSize: '48px',
-                      lineHeight: '58px',
-                      letterSpacing: '-0.01em',
-                    }}
-                  >
-                    NEXUS AI
-                  </h1>
+              )}
 
-                  {/* Navigation Tabs */}
-                  <NavigationTabs activeTab={activeTab} onTabChange={setActiveTab} />
+              <div className="flex flex-col gap-12 w-full mt-16">
+                <h1
+                  className="text-[#042E27] dark:text-[#A7B832]"
+                  style={{
+                    fontFamily: 'var(--font-rethink-sans)',
+                    fontWeight: 700,
+                    fontSize: '48px',
+                    lineHeight: '58px',
+                    letterSpacing: '-0.01em',
+                  }}
+                >
+                  {offering.name}
+                </h1>
 
-                  {/* Tab Content - Overview */}
-                  {activeTab === 'overview' && (
-                    <>
-                      {/* Highlights Section */}
-                      <HighlightsSection />
+                <NavigationTabs activeTab={activeTab} onTabChange={setActiveTab} />
 
-                      {/* Proprietary Edge Section */}
-                      <ProprietaryEdgeSection />
+                {activeTab === 'overview' && (
+                  <>
+                    <HighlightsSection statCards={statCards} bulletItems={bullets} />
 
-                      {/* Image Placeholders */}
+                    {proprietaryEdgeBlock && (
+                      <ProprietaryEdgeSection
+                        title={proprietaryEdgeBlock.title ?? 'Our Proprietary Edge'}
+                        summary={proprietaryEdgeBlock.summary ?? ''}
+                        items={mapBlockItems(proprietaryEdgeBlock)}
+                      />
+                    )}
+
+                    {galleryImages.length > 0 && (
                       <div className="flex flex-col gap-4 w-full" style={{ maxWidth: '816px' }}>
-                        <ImagePlaceholder width="816px" height="352px" />
-                        <ImagePlaceholder width="816px" height="352px" />
+                        {galleryImages.map((url) => (
+                          <ImagePlaceholder key={url} width="816px" height="352px" imageUrl={url} />
+                        ))}
                       </div>
+                    )}
 
-                      {/* Strong Market Traction & Financials Section */}
-                      <MarketTractionSection />
-                    </>
-                  )}
+                    {marketTractionBlock && (
+                      <MarketTractionSection
+                        title={marketTractionBlock.title ?? 'Market Traction'}
+                        summary={marketTractionBlock.summary ?? ''}
+                        items={mapBlockItems(marketTractionBlock)}
+                      />
+                    )}
+                  </>
+                )}
 
-                  {/* Tab Content - Details */}
-                  {activeTab === 'details' && (
-                    <>
-                      <TeamSection />
-                      <div style={{ marginTop: '64px' }}>
-                        <FinancialsSection />
-                      </div>
-                      <div style={{ marginTop: '64px' }}>
-                        <RisksMitigationSection />
-                      </div>
-                      <div style={{ marginTop: '64px' }}>
-                        <DocumentsSection />
-                      </div>
-                    </>
-                  )}
-
-                  {/* Tab Content - Updates */}
-                  {activeTab === 'updates' && (
-                    <>
-                      <UpdatesSection />
-                    </>
-                  )}
-
-                  {/* Tab Content - Testimonials */}
-                  {activeTab === 'testimonials' && (
-                    <>
-                      <TestimonialsSection />
-                    </>
-                  )}
-
-                  {/* Tab Content - Questions */}
-                  {activeTab === 'questions' && (
-                    <>
-                      <AskQuestionSection />
-                    </>
-                  )}
-
-                  {/* TL;DR Section - visible for Overview and Details tabs only */}
-                  {(activeTab === 'overview' || activeTab === 'details') && (
-                    <TLDRSection />
-                  )}
-
-                  {/* Start Trading Button - not shown for Questions tab */}
-                  {activeTab !== 'questions' && (
-                    <div className="w-full lg:block hidden" style={{ maxWidth: '816px', marginTop: '32px' }}>
-                      <ActionButton
-                        text="Start trading"
-                        variant="primary"
-                        width="100%"
-                        height="48px"
+                {activeTab === 'details' && (
+                  <>
+                    <TeamSection
+                      members={team.map((member) => ({
+                        name: member.name,
+                        title: member.title,
+                        bio: member.bio,
+                        imagePath: member.imageUrl,
+                      }))}
+                    />
+                    <div style={{ marginTop: '64px' }}>
+                      <FinancialsSection
+                        metrics={financials.metrics}
+                        useOfProceeds={financials.useOfProceeds}
+                        useOfProceedsIntro={useOfProceedsIntroBlock?.summary}
                       />
                     </div>
-                  )}
-                </div>
-              </div>
+                    <div style={{ marginTop: '64px' }}>
+                      <RisksMitigationSection risks={risks} />
+                    </div>
+                    <div style={{ marginTop: '64px' }}>
+                      <DocumentsSection documents={documents} corporateProfile={corporateProfile} />
+                    </div>
+                  </>
+                )}
 
-              {/* Right Column */}
-              <div className="flex flex-col items-start w-full max-w-full lg:w-auto lg:max-w-[400px] lg:flex-shrink-0 lg:sticky lg:top-20 lg:self-start">
-                {/* Investment Panel */}
-                <InvestmentPanel />
-                
-                {/* Divider Line */}
-                <div
-                  className="w-full lg:w-[400px] border-t border-[#EAEAEA] dark:border-[#404040] mt-8"
-                />
+                {activeTab === 'updates' && (
+                  <UpdatesSection updates={updates.items} />
+                )}
 
-                {/* Deal Terms Section */}
-                <div className="mt-8 w-full">
-                  <DealTermsSection />
-                </div>
+                {activeTab === 'testimonials' && (
+                  <TestimonialsSection testimonials={testimonials} />
+                )}
+
+                {activeTab === 'questions' && (
+                  <AskQuestionSection />
+                )}
+
+                {(activeTab === 'overview' || activeTab === 'details') && tldrBlock?.summary && (
+                  <TLDRSection summary={tldrBlock.summary} />
+                )}
+
+                {activeTab !== 'questions' && (
+                  <div className="w-full lg:block hidden" style={{ maxWidth: '816px', marginTop: '32px' }}>
+                    <ActionButton
+                      text="Start trading"
+                      variant="primary"
+                      width="100%"
+                      height="48px"
+                    />
+                  </div>
+                )}
               </div>
             </div>
-          </section>
-        </div>
 
-      {/* Mobile Sticky Start Trading Button - only visible on mobile and not on questions tab */}
+            <div className="flex flex-col items-start w-full max-w-full lg:w-auto lg:max-w-[400px] lg:flex-shrink-0 lg:sticky lg:top-20 lg:self-start">
+              <InvestmentPanel funding={funding} />
+
+              <div className="w-full lg:w-[400px] border-t border-[#EAEAEA] dark:border-[#404040] mt-8" />
+
+              <div className="mt-8 w-full">
+                <DealTermsSection dealTerms={dealTerms} companyName={offering.name} />
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
       {activeTab !== 'questions' && (
-        <div 
+        <div
           ref={stickyButtonRef}
           className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-[#EAEAEA] p-4 shadow-lg"
         >
@@ -343,4 +353,3 @@ export function InvestmentDetailPageContent({ investment }: InvestmentDetailPage
     </div>
   )
 }
-

--- a/src/app/(marketing)/explore/[id]/investment-detail-page-content.tsx
+++ b/src/app/(marketing)/explore/[id]/investment-detail-page-content.tsx
@@ -211,7 +211,7 @@ export function InvestmentDetailPageContent({ detail }: InvestmentDetailPageCont
             <div className="flex flex-col w-full lg:w-auto lg:flex-1" style={{ maxWidth: '816px' }}>
               <VideoSection videoUrl={videoUrl} coverImageUrl={offering.coverImageUrl} />
 
-              {(thumbnails.length > 0 || media.length > 0) && (
+              {(thumbnails.length > 0 || offering.coverImageUrl) && (
                 <div className="w-full mt-4">
                   <MediaThumbnails
                     thumbnails={

--- a/src/app/(marketing)/explore/[id]/page.tsx
+++ b/src/app/(marketing)/explore/[id]/page.tsx
@@ -1,6 +1,4 @@
-import { notFound } from 'next/navigation'
-import { InvestmentDetailPageContent } from './investment-detail-page-content'
-import { allInvestmentData } from '@/data/investments'
+import { InvestmentDetailPageClient } from './investment-detail-page-client'
 
 interface InvestmentDetailPageProps {
   params: Promise<{
@@ -8,20 +6,7 @@ interface InvestmentDetailPageProps {
   }>
 }
 
-export async function generateStaticParams() {
-  return allInvestmentData.map((investment) => ({
-    id: investment.id,
-  }))
-}
-
 export default async function InvestmentDetailPage({ params }: InvestmentDetailPageProps) {
   const { id } = await params
-  const investment = allInvestmentData.find((inv) => inv.id === id)
-
-  if (!investment) {
-    notFound()
-  }
-
-  return <InvestmentDetailPageContent investment={investment} />
+  return <InvestmentDetailPageClient idOrSlug={id} />
 }
-

--- a/src/app/(marketing)/explore/explore-page-content.tsx
+++ b/src/app/(marketing)/explore/explore-page-content.tsx
@@ -2,15 +2,14 @@
 
 import React from 'react'
 import { HeroSection } from '@/components/explore/organisms/hero-section'
-import { InvestmentOpportunities } from '@/components/landing/organisms/investment-opportunities'
+import { InvestmentInfiniteGrid } from '@/components/explore/organisms/investment-infinite-grid'
 import { CTASection } from '@/components/explore/organisms/cta-section'
 
 export function ExplorePageContent() {
   return (
     <div className="w-full relative">
       <HeroSection />
-      {/* Show all 12 investments on explore page */}
-      <InvestmentOpportunities />
+      <InvestmentInfiniteGrid />
       <CTASection />
     </div>
   )

--- a/src/components/explore/organisms/investment-infinite-grid.tsx
+++ b/src/components/explore/organisms/investment-infinite-grid.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+import { InvestmentCard } from "@/components/investment/organisms/investment-card";
+import { useInfiniteInvestments } from "@/hooks/use-infinite-investments";
+import { toInvestmentCardData } from "@/lib/investment-mappers";
+
+interface InvestmentInfiniteGridProps {
+  pageSize?: number;
+  category?: string;
+  risk?: string;
+  search?: string;
+}
+
+export function InvestmentInfiniteGrid({
+  pageSize,
+  category,
+  risk,
+  search,
+}: InvestmentInfiniteGridProps) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteInvestments({ pageSize, category, risk, search });
+
+  const items = useMemo(
+    () =>
+      data?.pages.flatMap((page) => page.items.map(toInvestmentCardData)) ?? [],
+    [data]
+  );
+
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasNextPage) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return (
+    <section className="w-full bg-background">
+      <div className="w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-12 xl:px-[104px] py-16 flex flex-col items-center gap-12">
+        <div className="flex flex-col items-start gap-14 w-full max-w-[1232px]">
+          <div className="flex flex-col items-start gap-2 max-w-[821px]">
+            <h2
+              className="text-foreground w-full"
+              style={{
+                fontFamily: "var(--font-rethink-sans)",
+                fontWeight: 500,
+                fontSize: "clamp(28px, 4vw, 48px)",
+                lineHeight: "1.208",
+                letterSpacing: "-0.01em",
+              }}
+            >
+              All investment opportunities
+            </h2>
+            <p
+              className="text-muted-foreground w-full"
+              style={{
+                fontFamily: "var(--font-dm-sans)",
+                fontWeight: 400,
+                fontSize: "clamp(14px, 1.8vw, 18px)",
+                lineHeight: "1.278",
+                letterSpacing: "-0.01em",
+              }}
+            >
+              Scroll to browse every verified startup on Antital. New deals load
+              automatically as you reach the bottom.
+            </p>
+          </div>
+
+          {isLoading && (
+            <p className="text-muted-foreground font-dm-sans w-full text-center">
+              Loading investment opportunities...
+            </p>
+          )}
+
+          {isError && (
+            <p className="text-destructive font-dm-sans w-full text-center">
+              Unable to load investment opportunities.
+            </p>
+          )}
+
+          {!isLoading && !isError && items.length === 0 && (
+            <p className="text-muted-foreground font-dm-sans w-full text-center">
+              No investment opportunities match your filters.
+            </p>
+          )}
+
+          {!isLoading && !isError && items.length > 0 && (
+            <>
+              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 place-items-center">
+                {items.map((investment) => (
+                  <InvestmentCard key={investment.id} data={investment} />
+                ))}
+              </div>
+
+              <div
+                ref={sentinelRef}
+                className="w-full flex flex-col items-center gap-2 py-4"
+                aria-hidden={!hasNextPage}
+              >
+                {isFetchingNextPage && (
+                  <p className="text-muted-foreground font-dm-sans text-sm">
+                    Loading more opportunities...
+                  </p>
+                )}
+                {!hasNextPage && totalCount > 0 && (
+                  <p className="text-muted-foreground font-dm-sans text-sm">
+                    Showing all {totalCount} opportunities
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/investment/molecules/financial-metrics-table.tsx
+++ b/src/components/investment/molecules/financial-metrics-table.tsx
@@ -1,172 +1,45 @@
 import React from 'react'
+import type { FinancialMetric } from '@/types/investment'
+import { buildFinancialTable } from '@/lib/investment-mappers'
 
-interface FinancialMetric {
-  metric: string
-  fy2024: string
-  fy2025: string
-  fy2027: string
+interface FinancialMetricsTableProps {
+  metrics: FinancialMetric[]
 }
 
-export function FinancialMetricsTable() {
-  const metrics: FinancialMetric[] = [
-    {
-      metric: 'Annual Recurring Revenue (ARR)',
-      fy2024: '₦675,000,000',
-      fy2025: '₦2,250,000,000',
-      fy2027: '₦15,750,000,000',
-    },
-    {
-      metric: 'Gross Margin (%)',
-      fy2024: '78%',
-      fy2025: '82%',
-      fy2027: '86%',
-    },
-    {
-      metric: 'Customer Acquisition Cost (CAC)',
-      fy2024: '₦4,500,000',
-      fy2025: '₦3,750,000',
-      fy2027: '₦2,250,000',
-    },
-    {
-      metric: 'Customer Lifetime Value (LTV)',
-      fy2024: '₦36,000,000',
-      fy2025: '₦42,000,000',
-      fy2027: '₦52,500,000',
-    },
-    {
-      metric: 'LTV:CAC Ratio',
-      fy2024: '8:1',
-      fy2025: '11.2:1',
-      fy2027: '17.5:1',
-    },
-    {
-      metric: 'Cash-Flow Positive Target',
-      fy2024: 'N/A',
-      fy2025: 'N/A',
-      fy2027: 'N/A',
-    },
-  ]
+export function FinancialMetricsTable({ metrics }: FinancialMetricsTableProps) {
+  const { periods, rows } = buildFinancialTable(metrics)
+
+  if (periods.length === 0) {
+    return null
+  }
 
   return (
     <div className="w-full overflow-x-auto" style={{ maxWidth: '816px' }}>
-      <table
-        className="w-full"
-        style={{
-          borderCollapse: 'collapse',
-        }}
-      >
+      <table className="w-full" style={{ borderCollapse: 'collapse' }}>
         <thead>
-          <tr
-            style={{
-              borderBottom: '1px solid #EAEAEA',
-            }}
-          >
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
+          <tr style={{ borderBottom: '1px solid #EAEAEA' }}>
+            <th className="text-left py-3 px-4 text-muted-foreground font-dm-sans text-sm font-medium">
               Key financial metrics
             </th>
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              FY 2024 (Actual)
-            </th>
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              FY 2025 (Projected)
-            </th>
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              FY 2027 (Projected)
-            </th>
+            {periods.map((period) => (
+              <th key={period} className="text-left py-3 px-4 text-muted-foreground font-dm-sans text-sm font-medium">
+                {period}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
-          {metrics.map((metric, index) => (
+          {rows.map((row, index) => (
             <tr
-              key={index}
-              style={{
-                borderBottom: index < metrics.length - 1 ? '1px solid #EAEAEA' : 'none',
-              }}
+              key={row.metric}
+              style={{ borderBottom: index < rows.length - 1 ? '1px solid #EAEAEA' : 'none' }}
             >
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                }}
-              >
-                {metric.metric}
-              </td>
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                }}
-              >
-                {metric.fy2024}
-              </td>
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                }}
-              >
-                {metric.fy2025}
-              </td>
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                }}
-              >
-                {metric.fy2027}
-              </td>
+              <td className="py-3 px-4 text-foreground font-dm-sans text-base">{row.metric}</td>
+              {row.values.map((value, valueIndex) => (
+                <td key={valueIndex} className="py-3 px-4 text-foreground font-dm-sans text-base">
+                  {value}
+                </td>
+              ))}
             </tr>
           ))}
         </tbody>
@@ -174,4 +47,3 @@ export function FinancialMetricsTable() {
     </div>
   )
 }
-

--- a/src/components/investment/molecules/image-placeholder.tsx
+++ b/src/components/investment/molecules/image-placeholder.tsx
@@ -1,31 +1,42 @@
 import React from 'react'
+import Image from 'next/image'
 
 interface ImagePlaceholderProps {
   width?: string
   height?: string
   className?: string
+  imageUrl?: string
 }
 
-export function ImagePlaceholder({ 
-  width = '816px', 
+export function ImagePlaceholder({
+  width = '816px',
   height = '352px',
-  className = ''
+  className = '',
+  imageUrl,
 }: ImagePlaceholderProps) {
-  // Calculate aspect ratio from width and height
   const widthNum = parseInt(width.replace('px', ''))
   const heightNum = parseInt(height.replace('px', ''))
   const aspectRatio = widthNum / heightNum
-  
+
   return (
     <div
-      className={`w-full ${className}`}
+      className={`w-full relative overflow-hidden rounded ${className}`}
       style={{
         maxWidth: width,
         aspectRatio: `${aspectRatio}`,
         minHeight: '200px',
-        background: '#D9D9D9',
+        background: imageUrl ? undefined : '#D9D9D9',
       }}
-    />
+    >
+      {imageUrl && (
+        <Image
+          src={imageUrl}
+          alt=""
+          fill
+          className="object-cover"
+          sizes="816px"
+        />
+      )}
+    </div>
   )
 }
-

--- a/src/components/investment/molecules/risks-mitigation-table.tsx
+++ b/src/components/investment/molecules/risks-mitigation-table.tsx
@@ -1,129 +1,31 @@
 import React from 'react'
+import type { OfferingRisk } from '@/types/investment'
 
-interface RiskItem {
-  category: string
-  riskDescription: string
-  mitigationDescription: string
+interface RisksMitigationTableProps {
+  risks: OfferingRisk[]
 }
 
-export function RisksMitigationTable() {
-  const risks: RiskItem[] = [
-    {
-      category: 'Market Risk',
-      riskDescription: 'Larger competitors (e.g., SAP, Oracle) could develop or acquire similar AI capabilities and target our SME market segment.',
-      mitigationDescription: 'We focus on an underserved market, maintain a high-speed development cycle (one major feature release per quarter), and build a defensible IP portfolio through patent filings.',
-    },
-    {
-      category: 'Technology Risk',
-      riskDescription: 'The accuracy of the Quantum-Sync Engine relies on the uninterrupted integrity of external real-time data feeds.',
-      mitigationDescription: 'We have diversified our data ingestion pipeline (no single point of failure) and maintain a proprietary, redundant Data Lake for real-time data cleansing and backup.',
-    },
-    {
-      category: 'Regulatory Risk',
-      riskDescription: 'New international data privacy laws (e.g., cross-border transfer) could necessitate costly re-engineering of the platform.',
-      mitigationDescription: 'We maintain a compliance-first architecture with modular data handling, allowing us to adapt to new regulations without full platform re-engineering. We also engage with legal experts to stay ahead of regulatory changes.',
-    },
-  ]
+export function RisksMitigationTable({ risks }: RisksMitigationTableProps) {
+  if (risks.length === 0) {
+    return null
+  }
 
   return (
     <div className="w-full overflow-x-auto" style={{ maxWidth: '816px' }}>
-      <table
-        className="w-full"
-        style={{
-          borderCollapse: 'collapse',
-        }}
-      >
+      <table className="w-full" style={{ borderCollapse: 'collapse' }}>
         <thead>
-          <tr
-            style={{
-              borderBottom: '1px solid #EAEAEA',
-            }}
-          >
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              Risk Category
-            </th>
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              Description
-            </th>
-            <th
-              className="text-left py-3 px-4 text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '14px',
-                lineHeight: '17px',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              Mitigation
-            </th>
+          <tr style={{ borderBottom: '1px solid #EAEAEA' }}>
+            <th className="text-left py-3 px-4 text-muted-foreground font-dm-sans text-sm font-medium">Risk Category</th>
+            <th className="text-left py-3 px-4 text-muted-foreground font-dm-sans text-sm font-medium">Description</th>
+            <th className="text-left py-3 px-4 text-muted-foreground font-dm-sans text-sm font-medium">Mitigation</th>
           </tr>
         </thead>
         <tbody>
           {risks.map((risk, index) => (
-            <tr
-              key={index}
-              style={{
-                borderBottom: index < risks.length - 1 ? '1px solid #EAEAEA' : 'none',
-              }}
-            >
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                  verticalAlign: 'top',
-                }}
-              >
-                {risk.category}
-              </td>
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                  verticalAlign: 'top',
-                }}
-              >
-                {risk.riskDescription}
-              </td>
-              <td
-                className="py-3 px-4 text-foreground"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                  verticalAlign: 'top',
-                }}
-              >
-                {risk.mitigationDescription}
-              </td>
+            <tr key={risk.id} style={{ borderBottom: index < risks.length - 1 ? '1px solid #EAEAEA' : 'none' }}>
+              <td className="py-3 px-4 text-foreground font-dm-sans text-base align-top">{risk.category}</td>
+              <td className="py-3 px-4 text-foreground font-dm-sans text-base align-top">{risk.description}</td>
+              <td className="py-3 px-4 text-foreground font-dm-sans text-base align-top">{risk.mitigation}</td>
             </tr>
           ))}
         </tbody>
@@ -131,4 +33,3 @@ export function RisksMitigationTable() {
     </div>
   )
 }
-

--- a/src/components/investment/molecules/use-of-proceeds.tsx
+++ b/src/components/investment/molecules/use-of-proceeds.tsx
@@ -35,7 +35,9 @@ export function UseOfProceeds({ items, intro }: UseOfProceedsProps) {
           <li key={item.id} className="w-full pl-6 relative">
             <span className="absolute left-0 text-foreground font-dm-sans font-medium">•</span>
             <span className="text-foreground font-dm-sans font-medium">
-              {item.allocationPercent != null ? `${item.allocationPercent}%` : ''} ({item.category}):
+              {item.allocationPercent != null
+                ? `${item.allocationPercent}% (${item.category}):`
+                : `${item.category}:`}
             </span>
             <span className="text-muted-foreground font-dm-sans"> {item.description}</span>
           </li>

--- a/src/components/investment/molecules/use-of-proceeds.tsx
+++ b/src/components/investment/molecules/use-of-proceeds.tsx
@@ -1,38 +1,18 @@
 import React from 'react'
+import type { UseOfProceedsItem } from '@/types/investment'
 
-interface UseOfProceedsItem {
-  percentage: string
-  category: string
-  description: string
+interface UseOfProceedsProps {
+  items: UseOfProceedsItem[]
+  intro?: string | null
 }
 
-export function UseOfProceeds() {
-  const items: UseOfProceedsItem[] = [
-    {
-      percentage: '50%',
-      category: '(R&D)',
-      description: 'Scaling the Engineering Team and accelerating development of V4.0 (Autonomous Bidding Engine).',
-    },
-    {
-      percentage: '30%',
-      category: '(Sales & Marketing)',
-      description: 'Expanding into two new economic zones (Kenya, South Africa) with dedicated sales hires.',
-    },
-    {
-      percentage: '20%',
-      category: '(Operations & Working Capital)',
-      description: 'Securing key data feed licenses and general operational expenses.',
-    },
-  ]
+export function UseOfProceeds({ items, intro }: UseOfProceedsProps) {
+  if (items.length === 0) {
+    return null
+  }
 
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '16px',
-      }}
-    >
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '16px' }}>
       <h3
         className="text-foreground"
         style={{
@@ -46,81 +26,21 @@ export function UseOfProceeds() {
         Use of Proceeds
       </h3>
 
-      <p
-        className="w-full text-muted-foreground"
-        style={{
-          fontFamily: 'var(--font-dm-sans)',
-          fontWeight: 400,
-          fontSize: '16px',
-          lineHeight: '21px',
-          letterSpacing: '0.01em',
-          marginBottom: '8px',
-        }}
-      >
-        This section details how the ₦3.75B being raised in the Seed Plus round will be strategically allocated to achieve product and market acceleration.
-      </p>
+      {intro && (
+        <p className="w-full text-muted-foreground font-dm-sans text-base mb-2">{intro}</p>
+      )}
 
-      <ul
-        className="flex flex-col items-start w-full"
-        style={{
-          gap: '12px',
-          listStyle: 'none',
-          padding: 0,
-        }}
-      >
-        {items.map((item, index) => (
-          <li
-            key={index}
-            className="w-full"
-            style={{
-              paddingLeft: '24px',
-              position: 'relative',
-            }}
-          >
-            {/* Bullet point */}
-            <span
-              className="text-foreground"
-              style={{
-                position: 'absolute',
-                left: '0',
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '16px',
-                lineHeight: '21px',
-                letterSpacing: '0.01em',
-              }}
-            >
-              •
+      <ul className="flex flex-col items-start w-full gap-3 list-none p-0">
+        {items.map((item) => (
+          <li key={item.id} className="w-full pl-6 relative">
+            <span className="absolute left-0 text-foreground font-dm-sans font-medium">•</span>
+            <span className="text-foreground font-dm-sans font-medium">
+              {item.allocationPercent != null ? `${item.allocationPercent}%` : ''} ({item.category}):
             </span>
-            {/* Content with label and description */}
-            <span
-              className="text-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 500,
-                fontSize: '16px',
-                lineHeight: '21px',
-                letterSpacing: '0.01em',
-              }}
-            >
-              {item.percentage} {item.category}:
-            </span>
-            <span
-              className="text-muted-foreground"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 400,
-                fontSize: '16px',
-                lineHeight: '21px',
-                letterSpacing: '0.01em',
-              }}
-            >
-              {' '}{item.description}
-            </span>
+            <span className="text-muted-foreground font-dm-sans"> {item.description}</span>
           </li>
         ))}
       </ul>
     </div>
   )
 }
-

--- a/src/components/investment/organisms/deal-terms-section.tsx
+++ b/src/components/investment/organisms/deal-terms-section.tsx
@@ -1,95 +1,78 @@
 import React from 'react'
 import { DealTermItem } from '@/components/investment/molecules/deal-term-item'
 import { ActionButton } from '@/components/investment/molecules/action-button'
+import type { DealTerms } from '@/types/investment'
+import { formatNaira, formatNumber } from '@/lib/investment-mappers'
 
-export function DealTermsSection() {
+interface DealTermsSectionProps {
+  dealTerms: DealTerms
+  companyName: string
+}
+
+export function DealTermsSection({ dealTerms, companyName }: DealTermsSectionProps) {
+  const deadline = new Date(dealTerms.deadline).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
   return (
     <div className="w-full max-w-full lg:w-auto lg:max-w-[400px]">
       <div
-        className="flex flex-col items-start bg-white dark:bg-[#1A1A1A] border border-[#EAEAEA] dark:border-[#404040] rounded overflow-hidden w-full max-w-full lg:w-[400px]"
-        style={{
-          height: 'auto',
-          padding: '16px',
-          gap: '32px',
-          boxShadow: '0px 4px 0px #042E27',
-          borderRadius: '4px',
-        }}
+        className="flex flex-col items-start bg-white dark:bg-[#1A1A1A] border border-[#EAEAEA] dark:border-[#404040] rounded overflow-hidden w-full max-w-full lg:w-[400px] p-4 gap-8"
+        style={{ boxShadow: '0px 4px 0px #042E27', borderRadius: '4px' }}
       >
-        {/* Deal Terms Heading */}
-        <h3
-          className="text-[#2C2C2C] dark:text-white"
-          style={{
-            fontFamily: 'var(--font-rethink-sans)',
-            fontWeight: 500,
-            fontSize: '28px',
-            lineHeight: '34px',
-            letterSpacing: '-0.01em',
-            width: '100%',
-          }}
-        >
+        <h3 className="text-[#2C2C2C] dark:text-white font-rethink-sans font-medium text-[28px] leading-[34px] w-full">
           Deal terms
         </h3>
 
-        {/* Deal Terms List */}
-        <div
-          className="flex flex-col items-start w-full"
-          style={{
-            width: '100%',
-          }}
-        >
-          <DealTermItem 
-            label="Total shares offered" 
-            value="99,431,817" 
-            description="The smallest investment amount that Nexus AI is accepting."
+        <div className="flex flex-col items-start w-full">
+          <DealTermItem
+            label="Total shares offered"
+            value={formatNumber(dealTerms.totalSharesOffered)}
+            description={`The total number of shares ${companyName} is offering.`}
           />
-          <DealTermItem 
-            label="Price per share" 
-            value="₦75" 
+          <DealTermItem
+            label="Price per share"
+            value={formatNaira(dealTerms.pricePerShare)}
             description="Price of a share"
-            showInfo 
+            showInfo
           />
-          <DealTermItem 
-            label="Minimum Investment" 
-            value="₦5,000" 
-            description="The smallest investment amount that Nexus AI is accepting."
-            showInfo 
+          <DealTermItem
+            label="Minimum Investment"
+            value={formatNaira(dealTerms.minimumInvestment)}
+            description={`The smallest investment amount that ${companyName} is accepting.`}
+            showInfo
           />
-          <DealTermItem 
-            label="Maximum Investment" 
-            value="₦250,000" 
-            description="The largest investment amount that Nexus AI is accepting."
-            showInfo 
+          <DealTermItem
+            label="Maximum Investment"
+            value={formatNaira(dealTerms.maximumInvestment)}
+            description={`The largest investment amount that ${companyName} is accepting.`}
+            showInfo
           />
-          <DealTermItem 
-            label="Minimum threshold" 
-            value="₦15M" 
+          <DealTermItem
+            label="Minimum threshold"
+            value={formatNaira(dealTerms.minimumThreshold)}
             description="The minimum amount the offering can raise."
-            showInfo 
+            showInfo
           />
-          <DealTermItem 
-            label="Funding goal" 
-            value="₦25M" 
+          <DealTermItem
+            label="Funding goal"
+            value={formatNaira(dealTerms.fundingGoal)}
             description="The maximum amount the offering can raise."
-            showInfo 
+            showInfo
           />
-          <DealTermItem 
-            label="Deadline" 
-            value="October 21, 2025" 
-            description="Nexus AI needs to reach their minimum funding goal before the deadline ( October 21, 2025 at 7:59 AM WAT). If they don't, all investments will be refunded."
-            showInfo 
-            isLast 
+          <DealTermItem
+            label="Deadline"
+            value={deadline}
+            description={`${companyName} needs to reach their minimum funding goal before the deadline (${deadline}). If they don't, all investments will be refunded.`}
+            showInfo
+            isLast
           />
         </div>
 
-        {/* Start Trading Button at Bottom */}
-        <ActionButton
-          text="Start trading"
-          variant="primary"
-          width="100%"
-          height="48px"
-        />
+        <ActionButton text="Start trading" variant="primary" width="100%" height="48px" />
       </div>
     </div>
   )
 }
-

--- a/src/components/investment/organisms/documents-section.tsx
+++ b/src/components/investment/organisms/documents-section.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 import Link from 'next/link'
 import { Download } from 'lucide-react'
+import type { CorporateProfile, OfferingDocument } from '@/types/investment'
 
-export function DocumentsSection() {
+interface DocumentsSectionProps {
+  documents: OfferingDocument[]
+  corporateProfile?: CorporateProfile | null
+}
+
+export function DocumentsSection({ documents, corporateProfile }: DocumentsSectionProps) {
+  const primaryDocument = documents[0]
+
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '32px',
-      }}
-    >
-      {/* Section Heading */}
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '32px' }}>
       <h2
         className="text-foreground"
         style={{
@@ -25,65 +26,30 @@ export function DocumentsSection() {
         Prospectus & Corporate Information
       </h2>
 
-      {/* Prospectus Information */}
-      <div
-        className="flex flex-col items-start w-full"
-        style={{
-          gap: '16px',
-        }}
-      >
-        <p
-          className="w-full text-muted-foreground"
-          style={{
-            fontFamily: 'var(--font-dm-sans)',
-            fontWeight: 400,
-            fontSize: '16px',
-            lineHeight: '21px',
-            letterSpacing: '0.01em',
-          }}
-        >
-          Prospectus (Downloadable PDF): Full legal document outlining the investment instrument, company structure, and risk disclosures.
-        </p>
+      {primaryDocument && (
+        <div className="flex flex-col items-start w-full gap-4">
+          <p className="w-full text-muted-foreground font-dm-sans text-base">
+            Prospectus (Downloadable PDF): Full legal document outlining the investment instrument, company structure, and risk disclosures.
+          </p>
+          <Link
+            href={primaryDocument.fileUrl}
+            className="flex flex-row items-center justify-center gap-2 px-4 py-3 bg-white border border-[#A8A8A8] text-foreground rounded hover:bg-[#A7B832] hover:text-[#11110F] hover:border-[#A7B832] transition-colors font-dm-sans font-medium text-base"
+          >
+            <Download className="w-5 h-5" />
+            <span>
+              Download {primaryDocument.title}
+              {primaryDocument.pageCount ? ` (${primaryDocument.pageCount} Pages)` : ''}
+            </span>
+          </Link>
+        </div>
+      )}
 
-        {/* Download Button */}
-        <Link
-          href="#"
-          className="flex flex-row items-center justify-center gap-2 px-4 py-3 bg-white border border-[#A8A8A8] text-foreground rounded hover:bg-[#A7B832] hover:text-[#11110F] hover:border-[#A7B832] transition-colors"
-          style={{
-            fontFamily: 'var(--font-dm-sans)',
-            fontWeight: 500,
-            fontSize: '16px',
-            lineHeight: '21px',
-            letterSpacing: '0.01em',
-            minWidth: 'fit-content',
-          }}
-        >
-          <Download className="w-5 h-5" />
-          <span>Download the Official Prospectus & Financial Model (45 Pages)</span>
-        </Link>
-      </div>
-
-      {/* Corporate Information */}
-      <div
-        className="flex flex-col items-start w-full"
-        style={{
-          gap: '8px',
-        }}
-      >
-        <p
-          className="w-full text-muted-foreground"
-          style={{
-            fontFamily: 'var(--font-dm-sans)',
-            fontWeight: 400,
-            fontSize: '16px',
-            lineHeight: '21px',
-            letterSpacing: '0.01em',
-          }}
-        >
-          Corporate Information: Incorporated in Lagos, Nigeria (C-Corp) in 2024. Primary Jurisdiction: Nigeria. Corporate Registration ID: NEX-NG-800532.
+      {corporateProfile && (
+        <p className="w-full text-muted-foreground font-dm-sans text-base">
+          Corporate Information: {corporateProfile.entityType} in {corporateProfile.jurisdiction} ({corporateProfile.incorporationYear}). Registration ID: {corporateProfile.registrationId}.
+          {corporateProfile.additionalNotes ? ` ${corporateProfile.additionalNotes}` : ''}
         </p>
-      </div>
+      )}
     </div>
   )
 }
-

--- a/src/components/investment/organisms/financials-section.tsx
+++ b/src/components/investment/organisms/financials-section.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import { FinancialMetricsTable } from '@/components/investment/molecules/financial-metrics-table'
 import { UseOfProceeds } from '@/components/investment/molecules/use-of-proceeds'
+import type { FinancialMetric, UseOfProceedsItem } from '@/types/investment'
 
-export function FinancialsSection() {
+interface FinancialsSectionProps {
+  metrics: FinancialMetric[]
+  useOfProceeds: UseOfProceedsItem[]
+  useOfProceedsIntro?: string | null
+}
+
+export function FinancialsSection({ metrics, useOfProceeds, useOfProceedsIntro }: FinancialsSectionProps) {
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '48px',
-      }}
-    >
-      {/* Section Heading */}
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '48px' }}>
       <h2
         className="text-foreground"
         style={{
@@ -25,12 +25,9 @@ export function FinancialsSection() {
         Financials
       </h2>
 
-      {/* Financial Metrics Table */}
-      <FinancialMetricsTable />
+      <FinancialMetricsTable metrics={metrics} />
 
-      {/* Use of Proceeds */}
-      <UseOfProceeds />
+      <UseOfProceeds items={useOfProceeds} intro={useOfProceedsIntro} />
     </div>
   )
 }
-

--- a/src/components/investment/organisms/highlights-section.tsx
+++ b/src/components/investment/organisms/highlights-section.tsx
@@ -2,35 +2,27 @@ import React from 'react'
 import { HighlightCard } from '@/components/investment/molecules/highlight-card'
 import { HighlightItem } from '@/components/investment/molecules/highlight-item'
 
-export function HighlightsSection() {
-  // Hardcoded data for now
-  const highlightCards = [
-    {
-      amount: '₦675M ARR',
-      description: 'Annual Recurring Revenue as of FY 2024',
-    },
-    {
-      amount: '50+ Clients',
-      description: 'Active clients across West African markets',
-    },
-  ]
+interface HighlightStat {
+  amount: string
+  description: string
+}
 
-  const highlightItems = [
-    { number: 1, text: 'Lifetime revenue of ₦2.1B across all clients' },
-    { number: 2, text: 'Average monthly revenue per client: ₦11.25M' },
-    { number: 3, text: 'Annual growth rate of 150% year-over-year' },
-    { number: 4, text: 'Customer acquisition cost (CAC) of ₦4.5M' },
-    { number: 5, text: 'Projected ARR for FY 2025: ₦2.25B' },
-  ]
+interface HighlightBullet {
+  number: number
+  text: string
+}
 
+interface HighlightsSectionProps {
+  statCards: HighlightStat[]
+  bulletItems: HighlightBullet[]
+}
+
+export function HighlightsSection({ statCards, bulletItems }: HighlightsSectionProps) {
   return (
     <div
       className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-      }}
+      style={{ maxWidth: '816px' }}
     >
-      {/* Highlights Heading */}
       <h2
         className="text-foreground"
         style={{
@@ -45,39 +37,36 @@ export function HighlightsSection() {
         Highlights
       </h2>
 
-      {/* Highlight Cards Row */}
-      <div
-        className="flex flex-row flex-wrap items-center w-full"
-        style={{
-          maxWidth: '608px',
-          minHeight: '113px',
-          gap: '16px',
-          marginBottom: '50px',
-        }}
-      >
-        {highlightCards.map((card, index) => (
-          <HighlightCard
-            key={index}
-            amount={card.amount}
-            description={card.description}
-          />
-        ))}
-      </div>
+      {statCards.length > 0 && (
+        <div
+          className="flex flex-row flex-wrap items-center w-full"
+          style={{
+            maxWidth: '608px',
+            minHeight: '113px',
+            gap: '16px',
+            marginBottom: '50px',
+          }}
+        >
+          {statCards.map((card, index) => (
+            <HighlightCard
+              key={index}
+              amount={card.amount}
+              description={card.description}
+            />
+          ))}
+        </div>
+      )}
 
-      {/* Highlight Items List */}
-      <div
-        className="flex flex-col items-start w-full"
-        style={{
-          maxWidth: '816px',
-          gap: '24px',
-          marginTop: '50px'
-        }}
-      >
-        {highlightItems.map((item) => (
-          <HighlightItem key={item.number} number={item.number} text={item.text} />
-        ))}
-      </div>
+      {bulletItems.length > 0 && (
+        <div
+          className="flex flex-col items-start w-full"
+          style={{ maxWidth: '816px', gap: '24px', marginTop: '50px' }}
+        >
+          {bulletItems.map((item) => (
+            <HighlightItem key={item.number} number={item.number} text={item.text} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
-

--- a/src/components/investment/organisms/investment-panel.tsx
+++ b/src/components/investment/organisms/investment-panel.tsx
@@ -3,9 +3,14 @@ import { Gauge, Bookmark } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { ActionButton } from '@/components/investment/molecules/action-button'
 import { useRouter } from "next/navigation"
+import type { OfferingFunding } from '@/types/investment'
+import { formatNaira, formatNumber } from '@/lib/investment-mappers'
 
-export function InvestmentPanel() {
+interface InvestmentPanelProps {
+  funding: OfferingFunding
+}
 
+export function InvestmentPanel({ funding }: InvestmentPanelProps) {
   const router = useRouter()
 
   const handleStartTrading = () => {
@@ -14,7 +19,6 @@ export function InvestmentPanel() {
 
   return (
     <div className="w-full max-w-full lg:w-auto lg:max-w-[400px]">
-      {/* Investment Card */}
       <div
         className="flex flex-col items-start bg-white dark:bg-white border border-[#EAEAEA] dark:border-[#404040] rounded w-full max-w-full lg:w-[400px]"
         style={{
@@ -25,173 +29,54 @@ export function InvestmentPanel() {
           borderRadius: '4px',
         }}
       >
-        {/* Top Section - Invest */}
-        <div
-          className="flex flex-col items-start w-full"
-          style={{
-            gap: '24px',
-          }}
-        >
-          {/* Target Section */}
-          <div
-            className="flex flex-col items-start w-full border-b border-[#EAEAEA] dark:border-[#404040]"
-            style={{
-              gap: '24px',
-              paddingBottom: '16px',
-            }}
-          >
-            {/* Target Header */}
+        <div className="flex flex-col items-start w-full gap-6">
+          <div className="flex flex-col items-start w-full border-b border-[#EAEAEA] dark:border-[#404040] gap-6 pb-4">
             <div className="flex flex-row justify-between items-center w-full">
-              <span
-                className="text-[#2C2C2C]"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '20px',
-                  lineHeight: '24px',
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                Target
-              </span>
+              <span className="text-[#2C2C2C] font-dm-sans text-xl">Target</span>
               <div className="flex flex-row items-center gap-2">
-                <Gauge className="w-6 h-6" style={{ color: '#A4D65E' }} />
-                <span
-                  className="text-[#000000]"
-                  style={{
-                    fontFamily: 'var(--font-dm-sans)',
-                    fontWeight: 400,
-                    fontSize: '20px',
-                    lineHeight: '24px',
-                    letterSpacing: '-0.01em',
-                  }}
-                >
-                  4.5
+                <Gauge className="w-6 h-6 text-[#A4D65E]" />
+                <span className="text-black font-dm-sans text-xl">
+                  {funding.targetRating ?? '—'}
                 </span>
               </div>
             </div>
 
-            {/* Progress Bar */}
             <div className="relative w-full h-1.5 bg-[#EDF7DF] rounded-lg overflow-hidden">
               <div
                 className="absolute left-0 top-0 h-full bg-[#A4D65E] rounded-lg"
-                style={{
-                  width: '48%', // Approximate based on CSS (176px / 368px)
-                }}
+                style={{ width: `${Math.min(100, funding.fundingProgressPercent)}%` }}
               />
             </div>
 
-            {/* Amount Raised */}
             <div className="flex flex-col items-start gap-2">
-              <span
-                className="text-[#2C2C2C]"
-                style={{
-                  fontFamily: 'var(--font-rethink-sans)',
-                  fontWeight: 500,
-                  fontSize: '24px',
-                  lineHeight: '29px',
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                ₦7,381,254
+              <span className="text-[#2C2C2C] font-rethink-sans font-medium text-2xl">
+                {formatNaira(funding.raisedAmount)}
               </span>
-              <span
-                className="text-[#858585]"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '14px',
-                  lineHeight: '17px',
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                raised from 341+ investors
+              <span className="text-[#858585] font-dm-sans text-sm">
+                raised from {formatNumber(funding.investorCount)}+ investors
               </span>
             </div>
           </div>
 
-          {/* Invest Section */}
-          <div
-            className="flex flex-row justify-between items-center w-full"
-            style={{
-              gap: '16px',
-              minHeight: '53px',
-            }}
-          >
-            {/* Invest Header */}
-            <div
-              className="flex flex-col items-start flex-shrink-0"
-              style={{
-                gap: '8px',
-                minWidth: '107px',
-              }}
-            >
-              <span
-                className="text-[#2C2C2C]"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '20px',
-                  lineHeight: '24px',
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                Invest
-              </span>
-              <span
-                className="text-[#858585]"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '16px',
-                  lineHeight: '21px',
-                  letterSpacing: '0.01em',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                1 share = ₦720
+          <div className="flex flex-row justify-between items-center w-full gap-4 min-h-[53px]">
+            <div className="flex flex-col items-start gap-2 min-w-[107px]">
+              <span className="text-[#2C2C2C] font-dm-sans text-xl">Invest</span>
+              <span className="text-[#858585] font-dm-sans text-base whitespace-nowrap">
+                1 share = {formatNaira(funding.sharePrice)}
               </span>
             </div>
 
-            {/* Input Field */}
-            <div className="relative flex-1 lg:max-w-[176px]" style={{ height: '44px' }}>
-              <div className="absolute left-3 top-1/2 -translate-y-1/2">
-                <span
-                  className="text-[#858585]"
-                  style={{
-                    fontFamily: 'var(--font-dm-sans)',
-                    fontWeight: 400,
-                    fontSize: '16px',
-                    lineHeight: '21px',
-                    letterSpacing: '0.01em',
-                  }}
-                >
-                  ₦
-                </span>
-              </div>
+            <div className="relative flex-1 lg:max-w-[176px] h-11">
+              <div className="absolute left-3 top-1/2 -translate-y-1/2 text-[#858585] font-dm-sans">₦</div>
               <Input
                 type="number"
                 placeholder="0"
-                className="w-full h-11 border border-[#B9CCFF] rounded pl-8 pr-3 text-[#2A2A2A] bg-white dark:bg-white"
-                style={{
-                  fontFamily: 'var(--font-dm-sans)',
-                  fontWeight: 400,
-                  fontSize: '20px',
-                  lineHeight: '24px',
-                  letterSpacing: '-0.01em',
-                }}
+                className="w-full h-11 border border-[#B9CCFF] rounded pl-8 pr-3 text-[#2A2A2A] bg-white dark:bg-white font-dm-sans text-xl"
               />
             </div>
           </div>
 
-          {/* Action Buttons */}
-          <div
-            className="flex flex-col w-full"
-            style={{
-              gap: '8px',
-              marginBottom: '24px',
-            }}
-          >
+          <div className="flex flex-col w-full gap-2 mb-6">
             <ActionButton
               text="Start trading"
               variant="primary"
@@ -213,4 +98,3 @@ export function InvestmentPanel() {
     </div>
   )
 }
-

--- a/src/components/investment/organisms/market-traction-section.tsx
+++ b/src/components/investment/organisms/market-traction-section.tsx
@@ -1,31 +1,15 @@
 import React from 'react'
 import { FeaturePoint } from '@/components/investment/molecules/feature-point'
 
-export function MarketTractionSection() {
-  // Hardcoded data for now
-  const heading = 'Strong Market Traction & Financials'
-  const mainDescription = 'NEXUS AI has demonstrated exceptional market traction with consistent revenue growth, strong customer retention, and expanding market presence. Our financial performance reflects a scalable, high-margin business model with clear path to profitability.'
-  
-  const features = [
-    {
-      label: 'Revenue Growth',
-      description: 'We have achieved 150% year-over-year revenue growth, with ARR increasing from ₦675M in FY 2024 to a projected ₦15.75B by FY 2027. Our customer base has grown from 12 clients in 2023 to 50+ active clients today, with a 95% retention rate.',
-    },
-    {
-      label: 'Market Expansion',
-      description: 'We have successfully expanded from serving only Nigerian SMEs to now operating in three West African markets. Our pipeline includes 120+ qualified leads, with conversion rates improving quarter-over-quarter as we refine our sales process and product-market fit.',
-    },
-  ]
+interface NarrativeSectionProps {
+  title: string
+  summary: string
+  items: { label: string; description: string }[]
+}
 
+export function MarketTractionSection({ title, summary, items }: NarrativeSectionProps) {
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '24px',
-      }}
-    >
-      {/* Heading */}
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '24px' }}>
       <h2
         className="text-foreground"
         style={{
@@ -36,10 +20,9 @@ export function MarketTractionSection() {
           letterSpacing: '-0.01em',
         }}
       >
-        {heading}
+        {title}
       </h2>
 
-      {/* Main Description */}
       <p
         className="w-full text-muted-foreground"
         style={{
@@ -51,22 +34,16 @@ export function MarketTractionSection() {
           maxWidth: '816px',
         }}
       >
-        {mainDescription}
+        {summary}
       </p>
 
-      {/* Feature Points */}
-      <div
-        className="flex flex-col items-start w-full"
-        style={{
-          maxWidth: '816px',
-          gap: '24px',
-        }}
-      >
-        {features.map((feature, index) => (
-          <FeaturePoint key={index} label={feature.label} description={feature.description} />
-        ))}
-      </div>
+      {items.length > 0 && (
+        <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '24px' }}>
+          {items.map((feature, index) => (
+            <FeaturePoint key={index} label={feature.label} description={feature.description} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
-

--- a/src/components/investment/organisms/proprietary-edge-section.tsx
+++ b/src/components/investment/organisms/proprietary-edge-section.tsx
@@ -1,32 +1,18 @@
 import React from 'react'
 import { FeaturePoint } from '@/components/investment/molecules/feature-point'
 
-export function ProprietaryEdgeSection() {
-  // Hardcoded data for now
-  const heading = 'Our Proprietary Edge: Technology & Scalability'
-  const mainDescription = 'At the core of NEXUS AI is the "Quantum-Sync Engine", a patent-pending algorithm that processes real-time data from disparate sources (weather, traffic, consumer sentiment) to create a single, unified supply chain forecast. This technology is 20x faster than competitors\' legacy systems.'
-  
-  const features = [
-    {
-      label: 'Scalability',
-      description: 'Our platform is built on a modular microservices architecture, allowing us to onboard new clients and expand into new sectors (e.g., e-commerce, healthcare logistics) with minimal friction and no performance degradation. We project a 300% increase in user capacity within the next 18 months.',
-    },
-    {
-      label: 'Defensible Moat',
-      description: 'Our proprietary dataset, accumulated over three years of beta testing with 50 pilot companies, gives us an insurmountable data advantage that improves the Quantum-Sync Engine\'s accuracy with every new transaction.',
-    },
-  ]
+interface NarrativeSectionProps {
+  title: string
+  summary: string
+  items: { label: string; description: string }[]
+}
 
+export function ProprietaryEdgeSection({ title, summary, items }: NarrativeSectionProps) {
   return (
     <div
       className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '24px',
-        marginTop: '64px',
-      }}
+      style={{ maxWidth: '816px', gap: '24px', marginTop: '64px' }}
     >
-      {/* Heading */}
       <h2
         className="text-foreground"
         style={{
@@ -37,10 +23,9 @@ export function ProprietaryEdgeSection() {
           letterSpacing: '-0.01em',
         }}
       >
-        {heading}
+        {title}
       </h2>
 
-      {/* Main Description */}
       <p
         className="w-full text-muted-foreground"
         style={{
@@ -52,22 +37,16 @@ export function ProprietaryEdgeSection() {
           maxWidth: '816px',
         }}
       >
-        {mainDescription}
+        {summary}
       </p>
 
-      {/* Feature Points */}
-      <div
-        className="flex flex-col items-start w-full"
-        style={{
-          maxWidth: '816px',
-          gap: '24px',
-        }}
-      >
-        {features.map((feature, index) => (
-          <FeaturePoint key={index} label={feature.label} description={feature.description} />
-        ))}
-      </div>
+      {items.length > 0 && (
+        <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '24px' }}>
+          {items.map((feature, index) => (
+            <FeaturePoint key={index} label={feature.label} description={feature.description} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
-

--- a/src/components/investment/organisms/risks-mitigation-section.tsx
+++ b/src/components/investment/organisms/risks-mitigation-section.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
+import type { OfferingRisk } from '@/types/investment'
 import { RisksMitigationTable } from '@/components/investment/molecules/risks-mitigation-table'
 
-export function RisksMitigationSection() {
+interface RisksMitigationSectionProps {
+  risks: OfferingRisk[]
+}
+
+export function RisksMitigationSection({ risks }: RisksMitigationSectionProps) {
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '24px',
-      }}
-    >
-      {/* Section Heading */}
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '24px' }}>
       <h2
         className="text-foreground"
         style={{
@@ -24,23 +22,11 @@ export function RisksMitigationSection() {
         Risks & Mitigation (Full Disclosure)
       </h2>
 
-      {/* Introductory Paragraph */}
-      <p
-        className="w-full text-muted-foreground"
-        style={{
-          fontFamily: 'var(--font-dm-sans)',
-          fontWeight: 400,
-          fontSize: '16px',
-          lineHeight: '21px',
-          letterSpacing: '0.01em',
-        }}
-      >
+      <p className="w-full text-muted-foreground font-dm-sans text-base">
         We maintain transparency with our investors by detailing potential risks and our strategies to manage them.
       </p>
 
-      {/* Risks & Mitigation Table */}
-      <RisksMitigationTable />
+      <RisksMitigationTable risks={risks} />
     </div>
   )
 }
-

--- a/src/components/investment/organisms/team-section.tsx
+++ b/src/components/investment/organisms/team-section.tsx
@@ -35,7 +35,7 @@ export function TeamSection({ members }: TeamSectionProps) {
             name={member.name}
             title={member.title}
             bio={member.bio}
-            imagePath={member.imagePath ?? '/avatars/default.jpg'}
+            imagePath={member.imagePath ?? '/avatars/adara.jpg'}
           />
         ))}
       </div>

--- a/src/components/investment/organisms/team-section.tsx
+++ b/src/components/investment/organisms/team-section.tsx
@@ -1,32 +1,20 @@
 import React from 'react'
-import { TeamMember } from '@/components/investment/molecules/team-member'
+import { TeamMember as TeamMemberCard } from '@/components/investment/molecules/team-member'
 
-export function TeamSection() {
-  // Hardcoded team data for now
-  const teamMembers = [
-    {
-      name: 'Dr. Eleanor Vance',
-      title: 'CEO & Co-founder',
-      bio: '20 years in global logistics and supply chain optimization. Former VP of Operations at TransGlobal Freight, where she managed a ₦750B annual budget and spearheaded the adoption of AI modeling. Ph.D. in Operations Research from MIT.',
-      imagePath: '/avatars/dr_eleanor.jpg',
-    },
-    {
-      name: 'Alex Chen',
-      title: 'CTO & Co-founder',
-      bio: '15 years in developing scalable machine learning platforms. Lead engineer at DataSolve Corp., where he built predictive models used by three Fortune 500 companies. Architect of the Quantum-Sync Engine. M.S. in Computer Science.',
-      imagePath: '/avatars/alex_chen.jpg',
-    },
-  ]
+export interface TeamMemberData {
+  name: string
+  title: string
+  bio: string
+  imagePath?: string | null
+}
 
+interface TeamSectionProps {
+  members: TeamMemberData[]
+}
+
+export function TeamSection({ members }: TeamSectionProps) {
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '48px',
-      }}
-    >
-      {/* Section Heading */}
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '48px' }}>
       <h2
         className="text-foreground"
         style={{
@@ -40,24 +28,17 @@ export function TeamSection() {
         Our Team
       </h2>
 
-      {/* Team Members List */}
-      <div
-        className="flex flex-col items-start w-full"
-        style={{
-          gap: '48px',
-        }}
-      >
-        {teamMembers.map((member, index) => (
-          <TeamMember
-            key={index}
+      <div className="flex flex-col items-start w-full" style={{ gap: '48px' }}>
+        {members.map((member, index) => (
+          <TeamMemberCard
+            key={`${member.name}-${index}`}
             name={member.name}
             title={member.title}
             bio={member.bio}
-            imagePath={member.imagePath}
+            imagePath={member.imagePath ?? '/avatars/default.jpg'}
           />
         ))}
       </div>
     </div>
   )
 }
-

--- a/src/components/investment/organisms/testimonials-section.tsx
+++ b/src/components/investment/organisms/testimonials-section.tsx
@@ -2,90 +2,33 @@
 
 import React from 'react'
 import { TestimonialItem } from '../molecules/testimonial-item'
-import { Button } from '@/components/ui/button'
+import type { Testimonial } from '@/types/investment'
 
-const testimonialsData = [
-  {
-    quote: "Investing in Nexus AI was a game-changer! The AI-driven supply chain solutions have greatly improved our efficiency. I'm excited to see what's next!",
-    author: "Adebayo A.",
-    avatar: "/avatars/Tunde.jpg",
-    likes: 45,
-    liked: true,
-  },
-  {
-    quote: "I'm so glad I invested in Nexus AI. Their innovative approach to logistics has already saved us time and money. Looking forward to the webinar!",
-    author: "Nkechi I.",
-    avatar: "/avatars/lady1.png",
-    likes: 32,
-    liked: false,
-  },
-  {
-    quote: "Being an early backer of Nexus AI has been incredibly rewarding. Their vision and execution are top-notch. Can't wait for the live Q&A!",
-    author: "Chinedu O.",
-    avatar: "/avatars/alex_chen.jpg",
-    likes: 28,
-    liked: false,
-  },
-  {
-    quote: "The partnership announcements are exciting! Nexus AI's strategic collaborations are a testament to their growth potential. Looking forward to the webinar to learn more!",
-    author: "Fatima Y.",
-    avatar: "/avatars/lady2.jpg",
-    likes: 42,
-    liked: false,
-  },
-  {
-    quote: "The beta program is fantastic! Providing feedback and shaping the future of Nexus AI's product is an amazing opportunity. Count me in!",
-    author: "Emeka D.",
-    avatar: "/avatars/ngozi.jpg",
-    likes: 15,
-    liked: true,
-  },
-]
+interface TestimonialsSectionProps {
+  testimonials: Testimonial[]
+}
 
-export function TestimonialsSection() {
+export function TestimonialsSection({ testimonials }: TestimonialsSectionProps) {
+  if (testimonials.length === 0) {
+    return (
+      <p className="text-muted-foreground font-dm-sans text-base">No testimonials yet.</p>
+    )
+  }
+
   return (
-    <div
-      className="flex flex-col items-center w-full max-w-[816px]"
-      style={{
-        gap: '32px',
-      }}
-    >
-      {/* Testimonials List */}
-      <div
-        className="flex flex-col items-center w-full"
-        style={{
-          gap: '32px',
-        }}
-      >
-        {testimonialsData.map((testimonial, index) => (
+    <div className="flex flex-col items-center w-full max-w-[816px] gap-8">
+      <div className="flex flex-col items-center w-full gap-8">
+        {testimonials.map((testimonial) => (
           <TestimonialItem
-            key={index}
+            key={testimonial.id}
             quote={testimonial.quote}
-            author={testimonial.author}
-            avatar={testimonial.avatar}
-            initialLikes={testimonial.likes}
-            initialLiked={testimonial.liked}
+            author={`${testimonial.authorName}${testimonial.authorTitle ? `, ${testimonial.authorTitle}` : ''}`}
+            avatar={testimonial.imageUrl ?? '/avatars/default.jpg'}
+            initialLikes={0}
+            initialLiked={false}
           />
         ))}
       </div>
-
-      {/* Read More Button */}
-      <Button
-        variant="outline"
-        className="border-[#A8A8A8] text-[#A7B832] hover:bg-[#A7B832] hover:text-white hover:border-[#A7B832] dark:hover:bg-[#A7B832] dark:hover:text-white dark:hover:border-[#A7B832]"
-        style={{
-          width: '111px',
-          height: '48px',
-          padding: '8px 16px',
-          borderRadius: '8px',
-          fontFamily: 'var(--font-rethink-sans)',
-          fontWeight: 500,
-          fontSize: '16px',
-          lineHeight: '21px',
-        }}
-      >
-        Read more
-      </Button>
     </div>
   )
 }

--- a/src/components/investment/organisms/testimonials-section.tsx
+++ b/src/components/investment/organisms/testimonials-section.tsx
@@ -23,7 +23,7 @@ export function TestimonialsSection({ testimonials }: TestimonialsSectionProps) 
             key={testimonial.id}
             quote={testimonial.quote}
             author={`${testimonial.authorName}${testimonial.authorTitle ? `, ${testimonial.authorTitle}` : ''}`}
-            avatar={testimonial.imageUrl ?? '/avatars/default.jpg'}
+            avatar={testimonial.imageUrl ?? '/avatars/adara.jpg'}
             initialLikes={0}
             initialLiked={false}
           />

--- a/src/components/investment/organisms/tldr-section.tsx
+++ b/src/components/investment/organisms/tldr-section.tsx
@@ -1,19 +1,12 @@
 import React from 'react'
 
-export function TLDRSection() {
-  // Hardcoded data for now
-  const heading = 'TL;DR'
-  const summary = 'NEXUS AI is dedicated to transforming supply chain operations for SMEs through advanced AI solutions, significantly improving efficiency and greatly minimizing waste across the board. Our cutting-edge technology offers unparalleled optimization, ensuring sustainable and cost-effective practices for businesses of all sizes, while also enhancing overall productivity and streamlining complex logistical challenges with ease.'
+interface TLDRSectionProps {
+  summary: string
+}
 
+export function TLDRSection({ summary }: TLDRSectionProps) {
   return (
-    <div
-      className="flex flex-col items-start w-full"
-      style={{
-        maxWidth: '816px',
-        gap: '24px',
-      }}
-    >
-      {/* Heading */}
+    <div className="flex flex-col items-start w-full" style={{ maxWidth: '816px', gap: '24px' }}>
       <h2
         className="text-foreground"
         style={{
@@ -24,10 +17,8 @@ export function TLDRSection() {
           letterSpacing: '-0.01em',
         }}
       >
-        {heading}
+        TL;DR
       </h2>
-
-      {/* Summary Paragraph */}
       <p
         className="w-full text-muted-foreground"
         style={{
@@ -44,4 +35,3 @@ export function TLDRSection() {
     </div>
   )
 }
-

--- a/src/components/investment/organisms/updates-section.tsx
+++ b/src/components/investment/organisms/updates-section.tsx
@@ -10,9 +10,9 @@ function formatUpdateDate(isoDate: string): string {
   const date = new Date(isoDate)
   const now = new Date()
   const isToday =
-    date.getUTCFullYear() === now.getUTCFullYear() &&
-    date.getUTCMonth() === now.getUTCMonth() &&
-    date.getUTCDate() === now.getUTCDate()
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate()
 
   if (isToday) {
     return 'Today'

--- a/src/components/investment/organisms/updates-section.tsx
+++ b/src/components/investment/organisms/updates-section.tsx
@@ -1,57 +1,51 @@
 import React from 'react'
 import { UpdateItem } from '@/components/investment/molecules/update-item'
+import type { OfferingUpdate } from '@/types/investment'
 
-export function UpdatesSection() {
-  // Hardcoded updates data for now
-  const updates = [
-    {
-      date: 'Today',
-      title: '🎉 75% Goal Reached! Only ₦937.5M left 🎉',
-      body: "Thank you to our 310 investors who have joined us! We are on track to close early. We're hosting a Founder AMA this Friday to answer all final questions before the final push.",
-      likeCount: 45,
-    },
-    {
-      date: '04 Oct 2025',
-      title: 'Quantum-Sync Engine V3.0 is Live',
-      body: "Introducing 'Predictive Rerouting.' This new feature automatically detects major supply chain anomalies (e.g., port closures, extreme weather) and reroutes cargo up to 48 hours in advance, reducing client delay costs by an average of 18%.",
-      likeCount: 90,
-    },
-    {
-      date: '27 Sept 2025',
-      title: 'Major Client Acquisition: Signed "Agri-West Produce"',
-      body: "We've secured a 3-year contract with Agri-West, a key player in West African fresh produce distribution. This validates our expansion into the cold chain logistics sector. ARR impact: +₦120,000,000.",
-      likeCount: 2,
-    },
-    {
-      date: '19 Sept 2025',
-      title: 'A Note on Global Expansion Plans.',
-      body: 'From Dr. Vance, CEO) Our vision isn\'t limited to our current markets. The capital from this round will be used to secure our first dedicated sales hires in two new key markets: Kenya and South Africa. See the Details tab for updated financial projections.',
-      likeCount: 32,
-    },
-  ]
+interface UpdatesSectionProps {
+  updates: OfferingUpdate[]
+}
+
+function formatUpdateDate(isoDate: string): string {
+  const date = new Date(isoDate)
+  const now = new Date()
+  const isToday =
+    date.getUTCFullYear() === now.getUTCFullYear() &&
+    date.getUTCMonth() === now.getUTCMonth() &&
+    date.getUTCDate() === now.getUTCDate()
+
+  if (isToday) {
+    return 'Today'
+  }
+
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+export function UpdatesSection({ updates }: UpdatesSectionProps) {
+  if (updates.length === 0) {
+    return (
+      <p className="text-muted-foreground font-dm-sans text-base">No updates yet.</p>
+    )
+  }
 
   return (
     <div
       className="flex flex-col items-start w-full relative"
-      style={{
-        maxWidth: '816px',
-        gap: '32px',
-        paddingLeft: '120px',
-      }}
+      style={{ maxWidth: '816px', gap: '32px', paddingLeft: '120px' }}
     >
-      {/* Continuous Vertical Line */}
       <div
         className="absolute left-[120px] top-0 bottom-0"
-        style={{
-          width: '1px',
-          backgroundColor: '#EAEAEA',
-        }}
+        style={{ width: '1px', backgroundColor: '#EAEAEA' }}
       />
 
-      {updates.map((update, index) => (
-        <div key={index} className="w-full relative">
+      {updates.map((update) => (
+        <div key={update.id} className="w-full relative">
           <UpdateItem
-            date={update.date}
+            date={formatUpdateDate(update.publishedAt)}
             title={update.title}
             body={update.body}
             likeCount={update.likeCount}
@@ -61,4 +55,3 @@ export function UpdatesSection() {
     </div>
   )
 }
-

--- a/src/components/investment/organisms/video-section.tsx
+++ b/src/components/investment/organisms/video-section.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
+import Image from 'next/image'
 import { Play } from 'lucide-react'
 
-export function VideoSection() {
+interface VideoSectionProps {
+  videoUrl?: string
+  coverImageUrl?: string
+}
+
+export function VideoSection({ videoUrl, coverImageUrl }: VideoSectionProps) {
   return (
     <div className="w-full" style={{ maxWidth: '816px' }}>
       <div
@@ -11,26 +17,37 @@ export function VideoSection() {
           minHeight: '200px',
         }}
       >
-        {/* Video Placeholder */}
-        <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-gray-300 to-gray-400">
+        {coverImageUrl && !videoUrl && (
+          <Image
+            src={coverImageUrl}
+            alt=""
+            fill
+            className="object-cover"
+            sizes="816px"
+            priority
+          />
+        )}
+
+        <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-gray-300/40 to-gray-400/40">
           <div className="flex flex-col items-center gap-4">
             <div className="w-20 h-20 rounded-full bg-black/50 flex items-center justify-center">
               <Play className="w-10 h-10 text-white ml-1" fill="white" />
             </div>
-            <span
-              className="text-gray-600"
-              style={{
-                fontFamily: 'var(--font-dm-sans)',
-                fontWeight: 400,
-                fontSize: '16px',
-              }}
-            >
-              Video Placeholder
-            </span>
+            {!coverImageUrl && (
+              <span
+                className="text-gray-600"
+                style={{
+                  fontFamily: 'var(--font-dm-sans)',
+                  fontWeight: 400,
+                  fontSize: '16px',
+                }}
+              >
+                Video Placeholder
+              </span>
+            )}
           </div>
         </div>
       </div>
     </div>
   )
 }
-

--- a/src/components/investment/organisms/video-section.tsx
+++ b/src/components/investment/organisms/video-section.tsx
@@ -7,7 +7,7 @@ interface VideoSectionProps {
   coverImageUrl?: string
 }
 
-export function VideoSection({ videoUrl, coverImageUrl }: VideoSectionProps) {
+export function VideoSection({ coverImageUrl }: VideoSectionProps) {
   return (
     <div className="w-full" style={{ maxWidth: '816px' }}>
       <div
@@ -17,7 +17,7 @@ export function VideoSection({ videoUrl, coverImageUrl }: VideoSectionProps) {
           minHeight: '200px',
         }}
       >
-        {coverImageUrl && !videoUrl && (
+        {coverImageUrl && (
           <Image
             src={coverImageUrl}
             alt=""

--- a/src/components/landing/organisms/investment-opportunities.tsx
+++ b/src/components/landing/organisms/investment-opportunities.tsx
@@ -1,28 +1,27 @@
 "use client"
 
 import React from 'react'
+import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { InvestmentCard } from '@/components/investment/organisms/investment-card'
-import { allInvestmentData } from '@/data/investments'
+import { useInvestments } from '@/hooks/use-investments'
+import { toInvestmentCardData } from '@/lib/investment-mappers'
 
 interface InvestmentOpportunitiesProps {
   limit?: number
 }
 
 export function InvestmentOpportunities({ limit }: InvestmentOpportunitiesProps) {
-  // Show first 6 on home page, all 12 on explore page
-  const displayData = limit ? allInvestmentData.slice(0, limit) : allInvestmentData
+  const pageSize = limit ?? 12
+  const { data, isLoading, isError } = useInvestments({ page: 1, pageSize })
+
+  const items = data?.items.map(toInvestmentCardData) ?? []
 
   return (
     <section className="w-full bg-background">
-      {/* Main Container - padding: 62px 0px, gap: 92px from Figma */}
       <div className="w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-12 xl:px-[104px] py-16 flex flex-col items-center gap-16 lg:gap-[92px]">
-        
-        {/* Section Header */}
         <div className="flex flex-col items-start gap-14 w-full max-w-[1232px]">
-          {/* Section Description */}
           <div className="flex flex-col items-start gap-2 max-w-[821px]">
-            {/* Section Title */}
             <h2
               className="text-foreground w-full"
               style={{
@@ -35,8 +34,6 @@ export function InvestmentOpportunities({ limit }: InvestmentOpportunitiesProps)
             >
               Invest in tomorrow&apos;s success stories today
             </h2>
-
-            {/* Section Subtitle */}
             <p
               className="text-muted-foreground w-full"
               style={{
@@ -51,16 +48,21 @@ export function InvestmentOpportunities({ limit }: InvestmentOpportunitiesProps)
             </p>
           </div>
 
-          {/* Projects Container */}
           <div className="flex flex-col items-center gap-12 w-full">
-            {/* Projects List - 3 cards per row on desktop */}
-            <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 place-items-center">
-              {displayData.map((investment) => (
-                <InvestmentCard key={investment.id} data={investment} />
-              ))}
-            </div>
+            {isLoading && (
+              <p className="text-muted-foreground font-dm-sans">Loading investment opportunities...</p>
+            )}
+            {isError && (
+              <p className="text-destructive font-dm-sans">Unable to load investment opportunities.</p>
+            )}
+            {!isLoading && !isError && (
+              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 place-items-center">
+                {items.map((investment) => (
+                  <InvestmentCard key={investment.id} data={investment} />
+                ))}
+              </div>
+            )}
 
-            {/* View All Button - no shadow on hover */}
             <Button
               variant="outline"
               className="bg-background dark:bg-background border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] dark:[&:hover]:bg-[#A7B832] dark:[&:hover]:text-[#11110F] dark:[&:hover]:border-[#A7B832] h-12 px-4 rounded-lg shadow-none [&:hover]:shadow-none transition-all duration-300"
@@ -71,8 +73,9 @@ export function InvestmentOpportunities({ limit }: InvestmentOpportunitiesProps)
                 fontSize: '16px',
                 lineHeight: '21px',
               }}
+              asChild
             >
-              View all
+              <Link href="/explore">View all</Link>
             </Button>
           </div>
         </div>
@@ -80,4 +83,3 @@ export function InvestmentOpportunities({ limit }: InvestmentOpportunitiesProps)
     </section>
   )
 }
-

--- a/src/components/landing/organisms/new-launches.tsx
+++ b/src/components/landing/organisms/new-launches.tsx
@@ -6,56 +6,13 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 import { InvestmentCard } from '@/components/investment/organisms/investment-card';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-
-// Dummy data for new launches (recently opened deals)
-const newLaunches = [
-  {
-    id: 'aquavera',
-    name: 'AquaPure Innovations',
-    category: 'Water Purification',
-    description: 'Next-gen filtration systems reducing contaminants by 90%',
-    image: '/investments/aqua_pure.jpg',
-    risk: 'moderate' as const,
-    investors: 150,
-    daysLeft: 150,
-    minInvestment: 500,
-    raised: 300000,
-    goal: 500000,
-    percentage: 60,
-  },
-  {
-    id: 'ecobuild',
-    name: 'EcoBuild Materials',
-    category: 'Sustainable Construction',
-    description: 'Biodegradable materials for eco-friendly building solutions',
-    image: '/investments/eco_build.jpg',
-    risk: 'high' as const,
-    investors: 120,
-    daysLeft: 120,
-    minInvestment: 2000,
-    raised: 600000,
-    goal: 800000,
-    percentage: 75,
-  },
-  {
-    id: 'smartwaste',
-    name: 'SmartWaste Technologies',
-    category: 'Waste Management',
-    description: 'AI-powered sorting systems for efficient recycling',
-    image: '/investments/smart_waste.jpg',
-    risk: 'low' as const,
-    investors: 90,
-    daysLeft: 90,
-    minInvestment: 1500,
-    raised: 250000,
-    goal: 500000,
-    percentage: 50,
-  },
-];
+import { useInvestments } from '@/hooks/use-investments';
+import { toInvestmentCardData } from '@/lib/investment-mappers';
 
 export function NewLaunches() {
-
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { data, isLoading, isError } = useInvestments({ page: 1, pageSize: 3 });
+  const items = data?.items.map(toInvestmentCardData) ?? [];
 
   const scrollLeft = () => {
     scrollRef.current?.scrollBy({ left: -380, behavior: "smooth" });
@@ -66,46 +23,38 @@ export function NewLaunches() {
   };
 
   return (
-    <section className="w-full bg-background py-[62px]"> {/* padding: 62px 0px, gap: 92px */}
+    <section className="w-full bg-background py-[62px]">
       <div className="w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-12 xl:px-[104px] flex flex-col items-center gap-[92px]">
-
-        {/* Section Header */}
-        <div className="flex flex-col items-start gap-14 w-full max-w-[1232px]"> {/* Section Header Container, gap: 56px */}
-
-          {/* Section Description */}
-          <div className="flex flex-col items-start gap-2 max-w-[821px]"> {/* gap: 8px */}
-            <h2
-              className="font-rethink-sans font-medium text-[36px] leading-[43px] tracking-[-0.01em] text-foreground"
-            >
+        <div className="flex flex-col items-start gap-14 w-full max-w-[1232px]">
+          <div className="flex flex-col items-start gap-2 max-w-[821px]">
+            <h2 className="font-rethink-sans font-medium text-[36px] leading-[43px] tracking-[-0.01em] text-foreground">
               New launches
             </h2>
-            <p
-              className="font-dm-sans font-normal text-[18px] leading-[23px] tracking-[-0.01em] text-muted-foreground"
-            >
+            <p className="font-dm-sans font-normal text-[18px] leading-[23px] tracking-[-0.01em] text-muted-foreground">
               The deals that have recently opened for investment
             </p>
           </div>
 
-          {/* Projects Container */}
-          <div className="flex flex-col items-center gap-12 w-full"> {/* gap: 48px */}
+          <div className="flex flex-col items-center gap-12 w-full">
+            {isLoading && (
+              <p className="text-muted-foreground font-dm-sans">Loading new launches...</p>
+            )}
+            {isError && (
+              <p className="text-destructive font-dm-sans">Unable to load new launches.</p>
+            )}
+            {!isLoading && !isError && (
+              <div
+                ref={scrollRef}
+                className="w-full flex gap-5 overflow-x-auto snap-x snap-mandatory md:grid md:grid-cols-2 lg:grid-cols-3 md:overflow-visible scrollbar-hide"
+              >
+                {items.map((project) => (
+                  <div key={project.id} className="flex-shrink-0 md:flex-shrink">
+                    <InvestmentCard data={project} />
+                  </div>
+                ))}
+              </div>
+            )}
 
-            {/* Projects List - Horizontal scroll on mobile, grid on larger screens */}
-            <div
-              ref={scrollRef}
-              className="w-full flex gap-5 overflow-x-auto snap-x snap-mandatory
-                        md:grid md:grid-cols-2 lg:grid-cols-3 md:overflow-visible scrollbar-hide"
-            >
-              {newLaunches.map((project) => (
-                <div
-                  key={project.id}
-                  className="flex-shrink-0 md:flex-shrink"
-                >
-                  <InvestmentCard data={project} />
-                </div>
-              ))}
-            </div>
-
-            {/* Mobile Navigation Buttons */}
             <div className="md:hidden w-full flex justify-end gap-8 -mt-4">
               <button
                 onClick={scrollLeft}
@@ -113,7 +62,6 @@ export function NewLaunches() {
               >
                 <ArrowLeft aria-label='Scroll left to previous investments' className="h-6 w-6 text-[#A8A8A8]" />
               </button>
-
               <button
                 onClick={scrollRight}
                 className="h-12 w-14 py-2 px-4 rounded-lg border border-[#A8A8A8] flex items-center justify-center hover:bg-[#F4F5F7] transition"
@@ -122,7 +70,6 @@ export function NewLaunches() {
               </button>
             </div>
 
-            {/* View All Button */}
             <Button
               variant="outline"
               className={cn(
@@ -133,13 +80,11 @@ export function NewLaunches() {
               )}
               asChild
             >
-              <Link href="/investments/new">View all</Link>
+              <Link href="/explore">View all</Link>
             </Button>
           </div>
-
         </div>
       </div>
     </section>
   );
 }
-

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const CACHE_KEY_USER = ["user"] as const;
+export const CACHE_KEY_INVESTMENTS = ["investments"] as const;
 
 export const ACCESS_TOKEN_KEY = "access_token";
 export const REFRESH_TOKEN_KEY = "refresh_token";

--- a/src/hooks/use-infinite-investments.ts
+++ b/src/hooks/use-infinite-investments.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { CACHE_KEY_INVESTMENTS } from "@/constants";
+import investmentService from "@/services/investmentService";
+
+const DEFAULT_PAGE_SIZE = 6;
+
+export function useInfiniteInvestments(params?: {
+  pageSize?: number;
+  category?: string;
+  risk?: string;
+  search?: string;
+}) {
+  const pageSize = params?.pageSize ?? DEFAULT_PAGE_SIZE;
+  const { category, risk, search } = params ?? {};
+
+  return useInfiniteQuery({
+    queryKey: [...CACHE_KEY_INVESTMENTS, "infinite", { pageSize, category, risk, search }],
+    queryFn: ({ pageParam }) =>
+      investmentService.getList({
+        page: pageParam,
+        pageSize,
+        category,
+        risk,
+        search,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const loaded = lastPage.page * lastPage.pageSize;
+      if (loaded >= lastPage.totalCount) {
+        return undefined;
+      }
+      return lastPage.page + 1;
+    },
+  });
+}

--- a/src/hooks/use-investment-detail.ts
+++ b/src/hooks/use-investment-detail.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CACHE_KEY_INVESTMENTS } from "@/constants";
+import investmentService from "@/services/investmentService";
+
+export function useInvestmentDetail(idOrSlug: string) {
+  return useQuery({
+    queryKey: [...CACHE_KEY_INVESTMENTS, "detail", idOrSlug],
+    queryFn: () => investmentService.getDetailBundle(idOrSlug),
+    enabled: Boolean(idOrSlug),
+  });
+}

--- a/src/hooks/use-investments.ts
+++ b/src/hooks/use-investments.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CACHE_KEY_INVESTMENTS } from "@/constants";
+import investmentService from "@/services/investmentService";
+
+export function useInvestments(params?: {
+  page?: number;
+  pageSize?: number;
+  category?: string;
+  risk?: string;
+  search?: string;
+}) {
+  return useQuery({
+    queryKey: [...CACHE_KEY_INVESTMENTS, "list", params ?? {}],
+    queryFn: () => investmentService.getList(params),
+  });
+}

--- a/src/lib/investment-mappers.ts
+++ b/src/lib/investment-mappers.ts
@@ -67,10 +67,11 @@ export function getVideoUrl(
 }
 
 export function splitHighlights(highlights: Highlight[]) {
-  const stats = highlights
+  const sorted = [...highlights].sort((a, b) => a.sortOrder - b.sortOrder);
+  const stats = sorted
     .filter((h) => h.kind === "stat")
     .map((h) => ({ amount: h.headline ?? "", description: h.body }));
-  const bullets = highlights
+  const bullets = sorted
     .filter((h) => h.kind === "bullet")
     .map((h, index) => ({ number: index + 1, text: h.body }));
   return { stats, bullets };

--- a/src/lib/investment-mappers.ts
+++ b/src/lib/investment-mappers.ts
@@ -1,0 +1,130 @@
+import type { InvestmentCardData } from "@/components/investment/organisms/investment-card";
+import type {
+  ContentBlock,
+  FinancialMetric,
+  Highlight,
+  InvestmentListItem,
+} from "@/types/investment";
+
+export function toInvestmentCardData(item: InvestmentListItem): InvestmentCardData {
+  return {
+    id: item.slug,
+    name: item.name,
+    category: item.category,
+    description: item.tagline,
+    image: item.coverImageUrl,
+    risk: item.risk,
+    investors: item.investorCount,
+    daysLeft: item.daysLeft ?? 0,
+    minInvestment: item.minInvestment,
+    raised: item.raisedAmount,
+    goal: item.fundingGoal,
+    percentage: item.fundingProgressPercent,
+  };
+}
+
+export function findContentBlock(
+  blocks: ContentBlock[],
+  predicate: (block: ContentBlock) => boolean
+): ContentBlock | undefined {
+  return blocks.find(predicate);
+}
+
+export function findContentBlockByKey(
+  blocks: ContentBlock[],
+  key: string
+): ContentBlock | undefined {
+  return blocks.find((b) => b.key === key);
+}
+
+export function findContentBlockByType(
+  blocks: ContentBlock[],
+  blockType: string
+): ContentBlock | undefined {
+  return blocks.find((b) => b.blockType === blockType);
+}
+
+export function mapBlockItems(block?: ContentBlock) {
+  return (block?.items ?? [])
+    .slice()
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((item) => ({ label: item.label, description: item.body }));
+}
+
+export function getMediaThumbnails(
+  media: { assetType: string; url: string; sortOrder: number }[]
+): string[] {
+  return media
+    .filter((m) => m.assetType.toLowerCase() === "thumbnail")
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((m) => m.url);
+}
+
+export function getVideoUrl(
+  media: { assetType: string; url: string }[]
+): string | undefined {
+  return media.find((m) => m.assetType.toLowerCase() === "video")?.url;
+}
+
+export function splitHighlights(highlights: Highlight[]) {
+  const stats = highlights
+    .filter((h) => h.kind === "stat")
+    .map((h) => ({ amount: h.headline ?? "", description: h.body }));
+  const bullets = highlights
+    .filter((h) => h.kind === "bullet")
+    .map((h, index) => ({ number: index + 1, text: h.body }));
+  return { stats, bullets };
+}
+
+export function formatFinancialMetricValue(metric: FinancialMetric): string {
+  if (metric.value == null) {
+    return "N/A";
+  }
+
+  switch (metric.unit) {
+    case "currency":
+      return new Intl.NumberFormat("en-NG", {
+        style: "currency",
+        currency: metric.currencyCode ?? "NGN",
+        maximumFractionDigits: 0,
+      }).format(metric.value);
+    case "percent":
+      return `${metric.value}%`;
+    default:
+      return String(metric.value);
+  }
+}
+
+export function buildFinancialTable(metrics: FinancialMetric[]) {
+  const periods = [...new Map(
+    metrics.map((m) => [m.periodLabel, m.periodSortOrder] as const)
+  ).entries()]
+    .sort(([, a], [, b]) => a - b)
+    .map(([label]) => label);
+
+  const metricNames = [...new Set(metrics.map((m) => m.metricName))];
+
+  const rows = metricNames.map((metricName) => {
+    const values = periods.map((periodLabel) => {
+      const metric = metrics.find(
+        (m) => m.metricName === metricName && m.periodLabel === periodLabel
+      );
+      return metric ? formatFinancialMetricValue(metric) : "N/A";
+    });
+    return { metric: metricName, values };
+  });
+
+  return { periods, rows };
+}
+
+export function formatNaira(amount: number): string {
+  return new Intl.NumberFormat("en-NG", {
+    style: "currency",
+    currency: "NGN",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function formatNumber(amount: number): string {
+  return new Intl.NumberFormat("en-NG").format(amount);
+}

--- a/src/services/investmentService.ts
+++ b/src/services/investmentService.ts
@@ -1,0 +1,143 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type {
+  ContentBlock,
+  Highlight,
+  InvestmentDetailBundle,
+  InvestmentListResponse,
+  MediaAsset,
+  OfferingDocument,
+  OfferingFinancials,
+  OfferingRisk,
+  OfferingShell,
+  OfferingUpdatesResponse,
+  TeamMember,
+  Testimonial,
+} from "@/types/investment";
+import { toApiError } from "@/lib/api-error";
+
+const BASE = "/api/investments";
+
+async function getList(params?: {
+  page?: number;
+  pageSize?: number;
+  category?: string;
+  risk?: string;
+  search?: string;
+}): Promise<InvestmentListResponse> {
+  try {
+    const res = await request.get<ApiResponse<InvestmentListResponse>>(BASE, {
+      params,
+    });
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function getShell(idOrSlug: string): Promise<OfferingShell> {
+  try {
+    const res = await request.get<ApiResponse<OfferingShell>>(`${BASE}/${idOrSlug}`);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function getHighlights(idOrSlug: string): Promise<Highlight[]> {
+  const res = await request.get<ApiResponse<Highlight[]>>(`${BASE}/${idOrSlug}/highlights`);
+  return unwrap(res.data);
+}
+
+async function getContentBlocks(idOrSlug: string): Promise<ContentBlock[]> {
+  const res = await request.get<ApiResponse<ContentBlock[]>>(`${BASE}/${idOrSlug}/content-blocks`);
+  return unwrap(res.data);
+}
+
+async function getTeam(idOrSlug: string): Promise<TeamMember[]> {
+  const res = await request.get<ApiResponse<TeamMember[]>>(`${BASE}/${idOrSlug}/team`);
+  return unwrap(res.data);
+}
+
+async function getFinancials(idOrSlug: string): Promise<OfferingFinancials> {
+  const res = await request.get<ApiResponse<OfferingFinancials>>(`${BASE}/${idOrSlug}/financials`);
+  return unwrap(res.data);
+}
+
+async function getRisks(idOrSlug: string): Promise<OfferingRisk[]> {
+  const res = await request.get<ApiResponse<OfferingRisk[]>>(`${BASE}/${idOrSlug}/risks`);
+  return unwrap(res.data);
+}
+
+async function getDocuments(idOrSlug: string): Promise<OfferingDocument[]> {
+  const res = await request.get<ApiResponse<OfferingDocument[]>>(`${BASE}/${idOrSlug}/documents`);
+  return unwrap(res.data);
+}
+
+async function getMedia(idOrSlug: string): Promise<MediaAsset[]> {
+  const res = await request.get<ApiResponse<MediaAsset[]>>(`${BASE}/${idOrSlug}/media`);
+  return unwrap(res.data);
+}
+
+async function getUpdates(idOrSlug: string, page = 1, pageSize = 20): Promise<OfferingUpdatesResponse> {
+  const res = await request.get<ApiResponse<OfferingUpdatesResponse>>(`${BASE}/${idOrSlug}/updates`, {
+    params: { page, pageSize },
+  });
+  return unwrap(res.data);
+}
+
+async function getTestimonials(idOrSlug: string): Promise<Testimonial[]> {
+  const res = await request.get<ApiResponse<Testimonial[]>>(`${BASE}/${idOrSlug}/testimonials`);
+  return unwrap(res.data);
+}
+
+async function getDetailBundle(idOrSlug: string): Promise<InvestmentDetailBundle> {
+  try {
+    const [
+      shell,
+      highlights,
+      contentBlocks,
+      team,
+      financials,
+      risks,
+      documents,
+      media,
+      updates,
+      testimonials,
+    ] = await Promise.all([
+      getShell(idOrSlug),
+      getHighlights(idOrSlug),
+      getContentBlocks(idOrSlug),
+      getTeam(idOrSlug),
+      getFinancials(idOrSlug),
+      getRisks(idOrSlug),
+      getDocuments(idOrSlug),
+      getMedia(idOrSlug),
+      getUpdates(idOrSlug),
+      getTestimonials(idOrSlug),
+    ]);
+
+    return {
+      shell,
+      highlights,
+      contentBlocks,
+      team,
+      financials,
+      risks,
+      documents,
+      media,
+      updates,
+      testimonials,
+    };
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const investmentService = {
+  getList,
+  getShell,
+  getDetailBundle,
+};
+
+export default investmentService;

--- a/src/types/investment.ts
+++ b/src/types/investment.ts
@@ -1,0 +1,188 @@
+export interface InvestmentListItem {
+  id: number;
+  slug: string;
+  name: string;
+  category: string;
+  tagline: string;
+  coverImageUrl: string;
+  risk: "low" | "moderate" | "high";
+  investorCount: number;
+  daysLeft: number | null;
+  minInvestment: number;
+  raisedAmount: number;
+  fundingGoal: number;
+  fundingProgressPercent: number;
+}
+
+export interface InvestmentListResponse {
+  items: InvestmentListItem[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+}
+
+export interface OfferingSummary {
+  id: number;
+  slug: string;
+  name: string;
+  category: string;
+  tagline: string;
+  coverImageUrl: string;
+  risk: string;
+  daysLeft: number | null;
+  status: string;
+}
+
+export interface OfferingFunding {
+  raisedAmount: number;
+  fundingGoal: number;
+  investorCount: number;
+  sharePrice: number;
+  targetRating: number | null;
+  minInvestment: number;
+  maxInvestment: number;
+  fundingProgressPercent: number;
+}
+
+export interface DealTerms {
+  totalSharesOffered: number;
+  pricePerShare: number;
+  minimumInvestment: number;
+  maximumInvestment: number;
+  minimumThreshold: number;
+  fundingGoal: number;
+  deadline: string;
+}
+
+export interface CorporateProfile {
+  entityType: string;
+  jurisdiction: string;
+  incorporationYear: number;
+  registrationId: string;
+  additionalNotes?: string | null;
+}
+
+export interface OfferingShell {
+  offering: OfferingSummary;
+  funding: OfferingFunding;
+  dealTerms: DealTerms;
+  corporateProfile: CorporateProfile | null;
+}
+
+export interface Highlight {
+  id: number;
+  kind: "stat" | "bullet";
+  headline: string | null;
+  body: string;
+  sortOrder: number;
+}
+
+export interface ContentBlockItem {
+  id: number;
+  label: string;
+  body: string;
+  sortOrder: number;
+}
+
+export interface ContentBlock {
+  id: number;
+  blockType: string;
+  key: string | null;
+  title: string | null;
+  summary: string | null;
+  sortOrder: number;
+  items: ContentBlockItem[];
+}
+
+export interface TeamMember {
+  id: number;
+  name: string;
+  title: string;
+  bio: string;
+  imageUrl: string | null;
+  sortOrder: number;
+}
+
+export interface FinancialMetric {
+  id: number;
+  metricName: string;
+  periodLabel: string;
+  periodSortOrder: number;
+  value: number | null;
+  unit: string;
+  currencyCode: string | null;
+  valueType: string;
+}
+
+export interface UseOfProceedsItem {
+  id: number;
+  allocationPercent: number | null;
+  category: string;
+  description: string;
+  sortOrder: number;
+}
+
+export interface OfferingFinancials {
+  metrics: FinancialMetric[];
+  useOfProceeds: UseOfProceedsItem[];
+}
+
+export interface OfferingRisk {
+  id: number;
+  category: string;
+  description: string;
+  mitigation: string;
+  sortOrder: number;
+}
+
+export interface OfferingDocument {
+  id: number;
+  title: string;
+  fileUrl: string;
+  documentType: string;
+  pageCount: number | null;
+}
+
+export interface MediaAsset {
+  id: number;
+  assetType: string;
+  url: string;
+  sortOrder: number;
+}
+
+export interface OfferingUpdate {
+  id: number;
+  publishedAt: string;
+  title: string;
+  body: string;
+  likeCount: number;
+}
+
+export interface OfferingUpdatesResponse {
+  items: OfferingUpdate[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+}
+
+export interface Testimonial {
+  id: number;
+  quote: string;
+  authorName: string;
+  authorTitle: string;
+  imageUrl: string | null;
+  sortOrder: number;
+}
+
+export interface InvestmentDetailBundle {
+  shell: OfferingShell;
+  highlights: Highlight[];
+  contentBlocks: ContentBlock[];
+  team: TeamMember[];
+  financials: OfferingFinancials;
+  risks: OfferingRisk[];
+  documents: OfferingDocument[];
+  media: MediaAsset[];
+  updates: OfferingUpdatesResponse;
+  testimonials: Testimonial[];
+}


### PR DESCRIPTION
## Summary
- Replaces static investment JSON with React Query hooks, service layer, and domain mappers wired to `/api/investments`.
- Landing/new-launches show API-backed cards; detail page composes shell + sub-resources into section components.
- Explore `/explore` uses infinite scroll (6 cards per page, auto-load on scroll) for View all.

## Test plan
- [x] Landing shows API investment cards (6 preview + View all link)
- [x] `/explore/greentech-solutions` renders GreenTech seed data (highlights, team, financials, funding panel)
- [x] `/explore` infinite scroll: 6 cards initially → 12 after scroll → "Showing all 12 opportunities"
- [x] `pnpm type-check` and pre-push `next build` pass

## Related
- Pairs with antital-api PR: `features/fundraiser-listing-and-details`


Made with [Cursor](https://cursor.com)