### PR TITLE
Wire investment checkout UI to Paystack

### DIFF
--- a/src/app/(auth)/sign-in/components/login.tsx
+++ b/src/app/(auth)/sign-in/components/login.tsx
@@ -37,10 +37,11 @@ export function Login({
 }: React.ComponentProps<"div">) {
   const [showPassword, setShowPassword] = useState(false)
   const searchParams = useSearchParams()
-  const loginMutation = useLogin()
 
   const from = searchParams.get("from")
   const isTrading = from === "trading"
+
+  const loginMutation = useLogin({ fromTrading: isTrading })
 
   const title = isTrading
     ? "Create an Account to Invest In NEXUS AI"
@@ -214,7 +215,7 @@ export function Login({
         }}
       >
         Don&apos;t have an account yet?{" "}
-        <Link href="/create-account" className="text-[#7BA147]">
+        <Link href={isTrading ? "/create-account?from=trading" : "/create-account"} className="text-[#7BA147]">
           Sign up
         </Link>
       </div>

--- a/src/app/(dashboard)/dashboard/components/data-table.tsx
+++ b/src/app/(dashboard)/dashboard/components/data-table.tsx
@@ -17,6 +17,7 @@ import Image from "next/image"
 import { usePathname, useRouter } from "next/navigation"
 import allInvestmentsRaw from "@/data/dashboardInvestmentData.json";
 import { InvestmentData, RISK_COLORS } from "@/types/dashboard"
+import { buildCheckoutPath } from "@/lib/investment-checkout";
 import type { DashboardHolding } from "@/types/dashboard-api"
 
 interface DataTableProps {
@@ -250,7 +251,10 @@ export function DataTable({ state = false, holdings, isLoading = false }: DataTa
                             className="border border-[#A8A8A8] px-4 py-1.5 rounded-lg text-[14px] font-medium hover:bg-gray-50 transition-colors whitespace-nowrap cursor-pointer"
                             onClick={() =>
                               router.push(
-                                `/marketplace/invest?company=${encodeURIComponent(row.name)}&minInvestment=${row.minInvestment}&price=${row.price}`
+                                buildCheckoutPath({
+                                  offeringId: Number.parseInt(row.id, 10) || 0,
+                                  slug: row.id,
+                                })
                               )
                             }
                           >

--- a/src/app/(dashboard)/marketplace/components/Marketplace.tsx
+++ b/src/app/(dashboard)/marketplace/components/Marketplace.tsx
@@ -2,18 +2,20 @@
 
 import { TYPOGRAPHY } from '@/constants/styles'
 import { InvestmentData, MarketType, RiskLevel, Sector } from '@/types/dashboard'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import investmentDataRaw from '@/data/dashboardInvestmentData.json'
 import { MarketFilterBar } from '@/components/marketplace/organisms/MarketplaceFilterBar'
-import { PrimaryMarketCard } from '@/components/marketplace/organisms/PrimaryMarketCard'
 import { SecondaryMarketCard } from '@/components/marketplace/organisms/SecondaryMarketCard'
+import { InvestmentCard } from '@/components/investment/organisms/investment-card'
 import { DataTable } from '../../dashboard/components/data-table'
 import { useSearchParams } from 'next/navigation'
+import { useInvestments } from '@/hooks/use-investments'
+import { toInvestmentCardData } from '@/lib/investment-mappers'
 
 type MarketFilters = {
     sector: Sector;
     risk: RiskLevel | "all";
-    tradeType?: "buy" | "sell"; // Optional because Primary doesn't use it
+    tradeType?: "buy" | "sell";
 };
 
 const marketTypes = [
@@ -23,6 +25,7 @@ const marketTypes = [
 
 const INVESTMENTS = investmentDataRaw as InvestmentData[]
 
+const PRIMARY_PAGE_SIZE = 24
 
 export function Marketplace() {
     const searchParams = useSearchParams();
@@ -32,19 +35,38 @@ export function Marketplace() {
         tabParam === "secondary" ? "secondary" : "primary"
     )
 
-    // Independent states for Primary Market
     const [primaryFilters, setPrimaryFilters] = useState({
         sector: "All Sector" as Sector,
         risk: "all" as RiskLevel | "all",
     });
 
-    // Independent states for Secondary Market
+    const [primarySearch, setPrimarySearch] = useState("");
+
     const [secondaryFilters, setSecondaryFilters] = useState({
         sector: "All Sector" as Sector,
         risk: "all" as RiskLevel | "all",
         tradeType: "buy" as "buy" | "sell"
     });
 
+    const primaryApiParams = useMemo(() => ({
+        page: 1,
+        pageSize: PRIMARY_PAGE_SIZE,
+        category: primaryFilters.sector === "All Sector" ? undefined : primaryFilters.sector,
+        risk: primaryFilters.risk === "all" ? undefined : primaryFilters.risk,
+        search: primarySearch.trim() || undefined,
+    }), [primaryFilters, primarySearch]);
+
+    const {
+        data: primaryData,
+        isLoading: isPrimaryLoading,
+        isError: isPrimaryError,
+        refetch: refetchPrimary,
+    } = useInvestments(primaryApiParams);
+
+    const primaryItems = useMemo(
+        () => primaryData?.items.map(toInvestmentCardData) ?? [],
+        [primaryData]
+    );
 
     const scrollRef = useRef<HTMLDivElement>(null);
     const [isAtBottom, setIsAtBottom] = useState(false);
@@ -67,27 +89,19 @@ export function Marketplace() {
         }
     };
 
-    const filteredData = INVESTMENTS.filter((item) => {
-        const marketMatch = item.market === activeMarket;
-
-        const filters = activeMarket === "primary" ? primaryFilters : secondaryFilters;
-
-        const sectorMatch = filters.sector === "All Sector" || item.sector === filters.sector;
-        const riskMatch = filters.risk === "all" || item.risk === filters.risk;
-
-        const tradeMatch = activeMarket === "primary" || item.tradeType === secondaryFilters.tradeType;
-
+    const filteredSecondaryData = INVESTMENTS.filter((item) => {
+        const marketMatch = item.market === "secondary";
+        const sectorMatch = secondaryFilters.sector === "All Sector" || item.sector === secondaryFilters.sector;
+        const riskMatch = secondaryFilters.risk === "all" || item.risk === secondaryFilters.risk;
+        const tradeMatch = item.tradeType === secondaryFilters.tradeType;
         return marketMatch && sectorMatch && riskMatch && tradeMatch;
     });
 
     const handleScrollAction = () => {
         if (scrollRef.current) {
-
             if (isAtBottom) {
-                // Scroll back to top
                 scrollRef.current.scrollTo({ top: 0, behavior: 'smooth' });
             } else {
-                // Scroll down
                 scrollRef.current.scrollBy({ top: 150, behavior: 'smooth' });
             }
         }
@@ -96,10 +110,15 @@ export function Marketplace() {
     const onScroll = () => {
         if (scrollRef.current) {
             const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
-            // If we are within 20px of the bottom, flip the arrow
             setIsAtBottom(scrollTop + clientHeight >= scrollHeight - 20);
         }
     }
+
+    const showPrimaryEmpty = !isPrimaryLoading && !isPrimaryError && primaryItems.length === 0;
+    const showSecondaryEmpty = filteredSecondaryData.length === 0;
+    const hasResults = activeMarket === "primary"
+        ? !isPrimaryLoading && !isPrimaryError && primaryItems.length > 0
+        : filteredSecondaryData.length > 0;
 
     return (
         <main>
@@ -111,7 +130,6 @@ export function Marketplace() {
                     Explore investment opportunities in both primary and secondary market
                 </p>
 
-                {/* Tab Navigation */}
                 <div className="flex gap-3 mb-6">
                     {marketTypes.map((market) => (
                         <button
@@ -152,24 +170,59 @@ export function Marketplace() {
                     tradeType={secondaryFilters.tradeType}
                     onTradeTypeChange={(val) => updateFilter('tradeType', val)}
 
-                    onRefresh={() => console.log("Refreshing data...")}
+                    onRefresh={() => {
+                        if (activeMarket === "primary") {
+                            void refetchPrimary();
+                        }
+                    }}
+                    searchValue={activeMarket === "primary" ? primarySearch : undefined}
+                    onSearchChange={activeMarket === "primary" ? setPrimarySearch : undefined}
                 />
 
-                {/* Conditional Rendering Area */}
                 <div
                     ref={scrollRef}
                     onScroll={onScroll}
                     className={`relative flex flex-col ${activeMarket === "primary" ? "max-h-[710px]" : "max-h-[520px]"} overflow-y-auto px-0 pt-2 mb-12 scrollbar-hide`}
                 >
-                    <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-                        {filteredData.map((investment) => (
-                            activeMarket === "primary"
-                                ? <PrimaryMarketCard key={investment.id} data={investment} />
-                                : <SecondaryMarketCard key={investment.id} data={investment} tradeType={secondaryFilters.tradeType} />
-                        ))}
-                    </div>
+                    {activeMarket === "primary" ? (
+                        <>
+                            {isPrimaryLoading && (
+                                <p className="text-[#505050] text-center py-12" style={TYPOGRAPHY.body}>
+                                    Loading investment opportunities...
+                                </p>
+                            )}
 
-                    {filteredData.length === 0 && (
+                            {isPrimaryError && (
+                                <p className="text-destructive text-center py-12" style={TYPOGRAPHY.body}>
+                                    Unable to load investment opportunities.
+                                </p>
+                            )}
+
+                            {!isPrimaryLoading && !isPrimaryError && (
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 place-items-center">
+                                    {primaryItems.map((investment) => (
+                                        <InvestmentCard
+                                            key={investment.id}
+                                            data={investment}
+                                            showInvestAction
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    ) : (
+                        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                            {filteredSecondaryData.map((investment) => (
+                                <SecondaryMarketCard
+                                    key={investment.id}
+                                    data={investment}
+                                    tradeType={secondaryFilters.tradeType}
+                                />
+                            ))}
+                        </div>
+                    )}
+
+                    {(activeMarket === "primary" ? showPrimaryEmpty : showSecondaryEmpty) && (
                         <div className="text-center py-20 border-2 border-dashed border-gray-200 rounded-xl">
                             <p className="text-[#505050]" style={TYPOGRAPHY.body}>
                                 No results match your selected filters. Try adjusting your criteria.
@@ -177,23 +230,24 @@ export function Marketplace() {
                         </div>
                     )}
 
-                    {filteredData.length !== 0 && (<div className="sticky bottom-0 left-1/2 -translate-x-1/2 z-10 w-fit mx-auto">
-                        <button
-                            onClick={handleScrollAction}
-                            className="w-10 h-10 rounded-full bg-[#344D44] flex items-center justify-center text-white shadow-lg transition-all active:scale-90 cursor-pointer"
-                        >
-                            <ChevronDownIcon
-                                className={`transition-transform duration-300 ${isAtBottom ? 'rotate-180' : ''}`}
-                            />
-                        </button>
-                    </div>)}
+                    {hasResults && (
+                        <div className="sticky bottom-0 left-1/2 -translate-x-1/2 z-10 w-fit mx-auto">
+                            <button
+                                onClick={handleScrollAction}
+                                className="w-10 h-10 rounded-full bg-[#344D44] flex items-center justify-center text-white shadow-lg transition-all active:scale-90 cursor-pointer"
+                            >
+                                <ChevronDownIcon
+                                    className={`transition-transform duration-300 ${isAtBottom ? 'rotate-180' : ''}`}
+                                />
+                            </button>
+                        </div>
+                    )}
                 </div>
             </div>
 
             <div>
                 <DataTable state={true} />
             </div>
-
         </main>
     )
 }
@@ -205,4 +259,3 @@ function ChevronDownIcon({ className }: { className?: string }) {
         </svg>
     );
 }
-

--- a/src/app/(dashboard)/marketplace/invest/InvestmentPaymentSummary.tsx
+++ b/src/app/(dashboard)/marketplace/invest/InvestmentPaymentSummary.tsx
@@ -7,10 +7,20 @@ interface InvestmentPaymentSummaryProps {
     userId: string;
     formattedDate: string;
     platformFee: number;
-    totalAmount: number
+    totalAmount: number;
+    subtotal?: number;
 }
 
-export function InvestmentPaymentSummary({ unitCount, unitPrice, userId, formattedDate, platformFee, totalAmount }: InvestmentPaymentSummaryProps) {
+export function InvestmentPaymentSummary({
+    unitCount,
+    unitPrice,
+    userId,
+    formattedDate,
+    platformFee,
+    totalAmount,
+    subtotal,
+}: InvestmentPaymentSummaryProps) {
+    const resolvedSubtotal = subtotal ?? unitCount * unitPrice;
     return (
         <div className="space-y-6">
             {/* User ID Card */}
@@ -48,7 +58,7 @@ export function InvestmentPaymentSummary({ unitCount, unitPrice, userId, formatt
 
                     <div className="flex justify-between text-[#505050] text-[16px]" style={TYPOGRAPHY.body}>
                         <p>Subtotal:</p>
-                        <p className="text-[#1B1B1B]">₦{(unitCount * unitPrice).toLocaleString()}.00</p>
+                        <p className="text-[#1B1B1B]">₦{resolvedSubtotal.toLocaleString()}.00</p>
                     </div>
 
                     <div className="flex justify-between text-[#505050] text-[16px]" style={TYPOGRAPHY.body}>

--- a/src/app/(dashboard)/marketplace/invest/MarketPlacePayment.tsx
+++ b/src/app/(dashboard)/marketplace/invest/MarketPlacePayment.tsx
@@ -1,17 +1,64 @@
 "use client"
 
 import { PaymentApplicationFee } from '@/components/onboarding/organisms/fundraiser/payment-application-fee/PaymentApplicationFee'
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useInvestmentCheckoutOffering } from '@/hooks/use-investment-checkout-offering'
+import { parseCheckoutSearchParams } from '@/lib/investment-checkout'
+import { useRouter, useSearchParams } from 'next/navigation'
 import React from 'react'
 
-
 export function MarketPlacePayment() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const checkoutContext = parseCheckoutSearchParams(searchParams)
+    const { data: shell, isLoading, isError } = useInvestmentCheckoutOffering(
+        checkoutContext?.slug ?? null
+    )
 
-    const companyName = searchParams.get('company');
-    const unitPrice = Number(searchParams.get("price")) || 0;
-    const minInvestment = Number(searchParams.get("minInvestment"))
+    const companyName = shell?.offering.name
+    const unitPrice = shell?.funding.sharePrice
+    const minInvestment = shell?.funding.minInvestment
+
+    if (!checkoutContext) {
+        return (
+            <div className="px-4 lg:px-8 min-h-screen flex items-center justify-center">
+                <div className="max-w-md text-center space-y-4">
+                    <p className="text-[#2C2C2C] text-lg">This checkout link is missing offering details.</p>
+                    <button
+                        type="button"
+                        className="text-[#7BA147] underline"
+                        onClick={() => router.push('/marketplace')}
+                    >
+                        Back to marketplace
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    if (isLoading) {
+        return (
+            <div className="px-4 lg:px-8 min-h-screen flex items-center justify-center">
+                <p className="text-[#505050]">Loading offering details…</p>
+            </div>
+        )
+    }
+
+    if (isError || !shell || !companyName || unitPrice == null || minInvestment == null) {
+        return (
+            <div className="px-4 lg:px-8 min-h-screen flex items-center justify-center">
+                <div className="max-w-md text-center space-y-4">
+                    <p className="text-[#2C2C2C] text-lg">Unable to load this investment offering.</p>
+                    <button
+                        type="button"
+                        className="text-[#7BA147] underline"
+                        onClick={() => router.push('/marketplace')}
+                    >
+                        Back to marketplace
+                    </button>
+                </div>
+            </div>
+        )
+    }
 
     return (
         <div className='px-4 lg:px-8 min-h-screen'>
@@ -32,7 +79,13 @@ export function MarketPlacePayment() {
             </div>
 
             <div className='lg:pt-14'>
-                <PaymentApplicationFee companyName={companyName!} unitPrice={unitPrice} minInvestment={minInvestment} />
+                <PaymentApplicationFee
+                    companyName={companyName}
+                    unitPrice={unitPrice}
+                    minInvestment={minInvestment}
+                    offeringId={checkoutContext.offeringId}
+                    offeringSlug={checkoutContext.slug}
+                />
             </div>
         </div>
     )

--- a/src/app/(dashboard)/marketplace/invest/callback/InvestCallbackContent.tsx
+++ b/src/app/(dashboard)/marketplace/invest/callback/InvestCallbackContent.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { PaymentSuccessPage } from "@/components/marketplace/organisms/PaymentSuccessPage";
+import investmentOrderService from "@/services/investmentOrderService";
+import investmentService from "@/services/investmentService";
+import {
+  clearCheckoutOrderId,
+  parseOrderIdFromPaystackReference,
+  readCheckoutOrderId,
+} from "@/lib/investment-checkout";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+const PAID_STATUS = "Paid";
+const FAILED_STATUSES = new Set(["Failed", "Expired", "Cancelled"]);
+
+export function InvestCallbackContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const orderId = useMemo(() => {
+    const fromSession = readCheckoutOrderId();
+    if (fromSession) return fromSession;
+
+    const reference = searchParams.get("reference") ?? searchParams.get("trxref");
+    return parseOrderIdFromPaystackReference(reference);
+  }, [searchParams]);
+
+  const orderQuery = useQuery({
+    queryKey: ["investment-order-callback", orderId],
+    queryFn: async () => {
+      try {
+        return await investmentOrderService.verifyPayment(orderId!);
+      } catch {
+        // Payment may still be pending; fall back to polling order status.
+        return investmentOrderService.getOrder(orderId!);
+      }
+    },
+    enabled: orderId != null,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (!status || status === PAID_STATUS || FAILED_STATUSES.has(status)) {
+        return false;
+      }
+      return 2000;
+    },
+  });
+
+  const offeringQuery = useQuery({
+    queryKey: ["investment-order-offering", orderQuery.data?.offeringId],
+    queryFn: () => investmentService.getShell(String(orderQuery.data!.offeringId)),
+    enabled: orderQuery.data?.status === PAID_STATUS,
+  });
+
+  if (!orderId) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-md text-center space-y-4">
+          <p className="text-[#2C2C2C] text-lg">We could not find your payment reference.</p>
+          <button
+            type="button"
+            className="text-[#7BA147] underline"
+            onClick={() => router.push("/marketplace")}
+          >
+            Back to marketplace
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (orderQuery.isLoading || !orderQuery.data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <p className="text-[#505050]">Confirming your payment…</p>
+      </div>
+    );
+  }
+
+  if (orderQuery.isError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-md text-center space-y-4">
+          <p className="text-[#2C2C2C] text-lg">Unable to confirm your payment right now.</p>
+          <button
+            type="button"
+            className="text-[#7BA147] underline"
+            onClick={() => orderQuery.refetch()}
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const order = orderQuery.data;
+
+  if (order.status === PAID_STATUS) {
+    clearCheckoutOrderId();
+    const companyName = offeringQuery.data?.offering.name ?? `Offering #${order.offeringId}`;
+    return (
+      <PaymentSuccessPage
+        totalAmount={order.totalAmount}
+        companyName={companyName}
+      />
+    );
+  }
+
+  if (FAILED_STATUSES.has(order.status)) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-md text-center space-y-4">
+          <p className="text-[#2C2C2C] text-lg">Payment was not completed.</p>
+          <p className="text-[#505050]">Order status: {order.status}</p>
+          <button
+            type="button"
+            className="text-[#7BA147] underline"
+            onClick={() => router.push("/marketplace")}
+          >
+            Back to marketplace
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <p className="text-[#505050]">Waiting for Paystack confirmation…</p>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/marketplace/invest/callback/page.tsx
+++ b/src/app/(dashboard)/marketplace/invest/callback/page.tsx
@@ -1,10 +1,10 @@
 import React, { Suspense } from 'react'
-import { MarketPlacePayment } from '@/app/(dashboard)/marketplace/invest/MarketPlacePayment'
+import { InvestCallbackContent } from './InvestCallbackContent'
 
-export default function page() {
+export default function InvestCallbackPage() {
     return (
         <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading…</div>}>
-            <MarketPlacePayment />
+            <InvestCallbackContent />
         </Suspense>
     )
 }

--- a/src/app/(marketing)/explore/[id]/investment-detail-page-content.tsx
+++ b/src/app/(marketing)/explore/[id]/investment-detail-page-content.tsx
@@ -30,6 +30,7 @@ import {
   mapBlockItems,
   splitHighlights,
 } from '@/lib/investment-mappers'
+import { useStartInvestmentCheckout } from '@/hooks/use-start-investment-checkout'
 
 interface InvestmentDetailPageContentProps {
   detail: InvestmentDetailBundle
@@ -58,6 +59,11 @@ const IS_IOS = typeof window !== 'undefined' && (
 export function InvestmentDetailPageContent({ detail }: InvestmentDetailPageContentProps) {
   const { shell, highlights, contentBlocks, team, financials, risks, documents, media, updates, testimonials } = detail
   const { offering, funding, dealTerms, corporateProfile } = shell
+  const startCheckout = useStartInvestmentCheckout()
+
+  const handleStartTrading = () => {
+    startCheckout({ offeringId: offering.id, slug: offering.slug })
+  }
 
   const { stats: statCards, bullets } = useMemo(() => splitHighlights(highlights), [highlights])
 
@@ -318,6 +324,7 @@ export function InvestmentDetailPageContent({ detail }: InvestmentDetailPageCont
                       variant="primary"
                       width="100%"
                       height="48px"
+                      onClick={handleStartTrading}
                     />
                   </div>
                 )}
@@ -325,12 +332,17 @@ export function InvestmentDetailPageContent({ detail }: InvestmentDetailPageCont
             </div>
 
             <div className="flex flex-col items-start w-full max-w-full lg:w-auto lg:max-w-[400px] lg:flex-shrink-0 lg:sticky lg:top-20 lg:self-start">
-              <InvestmentPanel funding={funding} />
+              <InvestmentPanel offeringId={offering.id} slug={offering.slug} funding={funding} />
 
               <div className="w-full lg:w-[400px] border-t border-[#EAEAEA] dark:border-[#404040] mt-8" />
 
               <div className="mt-8 w-full">
-                <DealTermsSection dealTerms={dealTerms} companyName={offering.name} />
+                <DealTermsSection
+                  dealTerms={dealTerms}
+                  companyName={offering.name}
+                  offeringId={offering.id}
+                  slug={offering.slug}
+                />
               </div>
             </div>
           </div>
@@ -347,6 +359,7 @@ export function InvestmentDetailPageContent({ detail }: InvestmentDetailPageCont
             variant="primary"
             width="100%"
             height="48px"
+            onClick={handleStartTrading}
           />
         </div>
       )}

--- a/src/components/investment/organisms/deal-terms-section.tsx
+++ b/src/components/investment/organisms/deal-terms-section.tsx
@@ -3,13 +3,17 @@ import { DealTermItem } from '@/components/investment/molecules/deal-term-item'
 import { ActionButton } from '@/components/investment/molecules/action-button'
 import type { DealTerms } from '@/types/investment'
 import { formatNaira, formatNumber } from '@/lib/investment-mappers'
+import { useStartInvestmentCheckout } from '@/hooks/use-start-investment-checkout'
 
 interface DealTermsSectionProps {
   dealTerms: DealTerms
   companyName: string
+  offeringId: number
+  slug: string
 }
 
-export function DealTermsSection({ dealTerms, companyName }: DealTermsSectionProps) {
+export function DealTermsSection({ dealTerms, companyName, offeringId, slug }: DealTermsSectionProps) {
+  const startCheckout = useStartInvestmentCheckout()
   const deadline = new Date(dealTerms.deadline).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
@@ -71,7 +75,13 @@ export function DealTermsSection({ dealTerms, companyName }: DealTermsSectionPro
           />
         </div>
 
-        <ActionButton text="Start trading" variant="primary" width="100%" height="48px" />
+        <ActionButton
+          text="Start trading"
+          variant="primary"
+          width="100%"
+          height="48px"
+          onClick={() => startCheckout({ offeringId, slug })}
+        />
       </div>
     </div>
   )

--- a/src/components/investment/organisms/investment-card.tsx
+++ b/src/components/investment/organisms/investment-card.tsx
@@ -7,9 +7,12 @@ import { Button } from '@/components/ui/button'
 import { RiskBadge } from '../atoms/risk-badge'
 import { StatItem } from '../molecules/stat-item'
 import { FundingProgress } from '../molecules/funding-progress'
+import { buildCheckoutPath } from '@/lib/investment-checkout'
 
 export interface InvestmentCardData {
   id: string
+  offeringId: number
+  slug: string
   name: string
   category: string
   description: string
@@ -25,9 +28,10 @@ export interface InvestmentCardData {
 
 interface InvestmentCardProps {
   data: InvestmentCardData
+  showInvestAction?: boolean
 }
 
-export function InvestmentCard({ data }: InvestmentCardProps) {
+export function InvestmentCard({ data, showInvestAction = false }: InvestmentCardProps) {
   const {
     id,
     name,
@@ -144,22 +148,46 @@ export function InvestmentCard({ data }: InvestmentCardProps) {
               />
             </div>
 
-            {/* View Details Button - width: 365px, height: 48px from Figma */}
-            <Button
-              variant="outline"
-              className="h-12 w-full max-w-[326px] md:max-w-[365px] bg-white dark:bg-white border-[#365852] text-[#365852] [&:hover]:bg-[#365852] [&:hover]:text-white [&:hover]:border-[#365852] dark:[&:hover]:bg-[#365852] dark:[&:hover]:text-white dark:[&:hover]:border-[#365852] rounded-lg shadow-none [&:hover]:shadow-[0_6px_0px_rgba(0,0,0,0.25)] transition-all duration-300"
-              style={{
-                fontFamily: 'var(--font-rethink-sans)',
-                fontWeight: 500,
-                fontSize: '16px',
-                lineHeight: '21px',
-              }}
-              asChild
-            >
-              <Link href={`/explore/${id}`}>
-                View Details
-              </Link>
-            </Button>
+            {/* Actions */}
+            <div className={`flex w-full max-w-[326px] md:max-w-[365px] gap-3 ${showInvestAction ? "flex-col sm:flex-row" : ""}`}>
+              <Button
+                variant="outline"
+                className={`h-12 bg-white dark:bg-white border-[#365852] text-[#365852] [&:hover]:bg-[#365852] [&:hover]:text-white [&:hover]:border-[#365852] dark:[&:hover]:bg-[#365852] dark:[&:hover]:text-white dark:[&:hover]:border-[#365852] rounded-lg shadow-none [&:hover]:shadow-[0_6px_0px_rgba(0,0,0,0.25)] transition-all duration-300 ${showInvestAction ? "flex-1 w-full" : "w-full"}`}
+                style={{
+                  fontFamily: 'var(--font-rethink-sans)',
+                  fontWeight: 500,
+                  fontSize: '16px',
+                  lineHeight: '21px',
+                }}
+                asChild
+              >
+                <Link href={`/explore/${id}`}>
+                  View Details
+                </Link>
+              </Button>
+
+              {showInvestAction && (
+                <Button
+                  className="h-12 flex-1 w-full bg-[#00332C] text-white [&:hover]:bg-[#00332C] rounded-lg shadow-none transition-all duration-300"
+                  style={{
+                    fontFamily: 'var(--font-rethink-sans)',
+                    fontWeight: 500,
+                    fontSize: '16px',
+                    lineHeight: '21px',
+                  }}
+                  asChild
+                >
+                  <Link
+                    href={buildCheckoutPath({
+                      offeringId: data.offeringId,
+                      slug: data.slug,
+                    })}
+                  >
+                    Invest Now
+                  </Link>
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/investment/organisms/investment-panel.tsx
+++ b/src/components/investment/organisms/investment-panel.tsx
@@ -2,19 +2,21 @@ import React from 'react'
 import { Gauge, Bookmark } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { ActionButton } from '@/components/investment/molecules/action-button'
-import { useRouter } from "next/navigation"
 import type { OfferingFunding } from '@/types/investment'
 import { formatNaira, formatNumber } from '@/lib/investment-mappers'
+import { useStartInvestmentCheckout } from '@/hooks/use-start-investment-checkout'
 
 interface InvestmentPanelProps {
+  offeringId: number
+  slug: string
   funding: OfferingFunding
 }
 
-export function InvestmentPanel({ funding }: InvestmentPanelProps) {
-  const router = useRouter()
+export function InvestmentPanel({ offeringId, slug, funding }: InvestmentPanelProps) {
+  const startCheckout = useStartInvestmentCheckout()
 
   const handleStartTrading = () => {
-    router.push("/sign-in?from=trading")
+    startCheckout({ offeringId, slug })
   }
 
   return (

--- a/src/components/marketplace/organisms/MarketplaceFilterBar.tsx
+++ b/src/components/marketplace/organisms/MarketplaceFilterBar.tsx
@@ -7,18 +7,31 @@ import { MarketType, RiskLevel, Sector } from "@/types/dashboard";
 
 interface MarketFilterBarProps {
     marketType: MarketType;
-    activeSector: Sector; // Updated from string
+    activeSector: Sector;
     onSectorChange: (sector: Sector) => void;
     activeRisk: RiskLevel | "all";
     onRiskChange: (risk: RiskLevel | "all") => void;
     tradeType?: "buy" | "sell";
     onTradeTypeChange?: (type: "buy" | "sell") => void;
     onRefresh?: () => void;
+    searchValue?: string;
+    onSearchChange?: (value: string) => void;
 }
 
 const sectors: Sector[] = ["All Sector", "Technology", "Health", "Energy", "Agriculture"];
 
-export function MarketFilterBar({ marketType, activeSector, onSectorChange, activeRisk, onRiskChange, tradeType, onTradeTypeChange, onRefresh }: MarketFilterBarProps) {
+export function MarketFilterBar({
+    marketType,
+    activeSector,
+    onSectorChange,
+    activeRisk,
+    onRiskChange,
+    tradeType,
+    onTradeTypeChange,
+    onRefresh,
+    searchValue = "",
+    onSearchChange,
+}: MarketFilterBarProps) {
 
     const isPrimary = marketType === "primary";
 
@@ -87,6 +100,8 @@ export function MarketFilterBar({ marketType, activeSector, onSectorChange, acti
                         <Input
                             type="search"
                             placeholder="Search"
+                            value={searchValue}
+                            onChange={(event) => onSearchChange?.(event.target.value)}
                             className="h-[40px] px-4 pr-12 bg-[#EAEAEA] border-[#EAEAEA] rounded-xs text-[16px]"
                             style={TYPOGRAPHY.body}
                         />

--- a/src/components/marketplace/organisms/PrimaryMarketCard.tsx
+++ b/src/components/marketplace/organisms/PrimaryMarketCard.tsx
@@ -4,6 +4,7 @@ import { ProgressBar } from '@/components/ui/progress-bar'
 import Image from 'next/image'
 import { Clock4 } from 'lucide-react'
 import { useRouter } from "next/navigation";
+import { buildCheckoutPath } from "@/lib/investment-checkout";
 
 const getInitials = (name: string) => {
     return name
@@ -107,7 +108,10 @@ export function PrimaryMarketCard({ data }: { data: InvestmentData }) {
                     e.stopPropagation();
 
                     router.push(
-                        `/marketplace/invest?company=${encodeURIComponent(data.name)}&minInvestment=${data.minInvestment}&price=${data.price}`
+                        buildCheckoutPath({
+                            offeringId: Number.parseInt(data.id, 10) || 0,
+                            slug: data.id,
+                        })
                     );
                 }}
             >

--- a/src/components/onboarding/organisms/fundraiser/payment-application-fee/PaymentApplicationFee.tsx
+++ b/src/components/onboarding/organisms/fundraiser/payment-application-fee/PaymentApplicationFee.tsx
@@ -11,30 +11,48 @@ import { PaymentMethodSelect } from "@/components/onboarding/organisms/fundraise
 import { PaymentCardDetails } from "@/components/onboarding/organisms/fundraiser/payment-application-fee/PaymentCardDetails"
 import { useOnboardingStore } from "@/store/onboardingStore"
 import { PAYMENT_SUBSTEPS } from "@/constants/paymentStep"
-import { useUserStore } from "@/store/userStore"
 import { InvestmentPaymentSummary } from "@/app/(dashboard)/marketplace/invest/InvestmentPaymentSummary"
 import { PaymentSuccessPage } from "@/components/marketplace/organisms/PaymentSuccessPage"
 import onboardingService from "@/services/onboardingService"
+import investmentOrderService from "@/services/investmentOrderService"
 import { showApiErrorToast } from "@/lib/error-feedback"
+import { useCurrentUser } from "@/hooks/use-current-user"
+import { getUserIdFromAccessToken } from "@/lib/jwt"
+import { tokenStorage } from "@/lib/token-storage"
+import { saveCheckoutOrderId } from "@/lib/investment-checkout"
+import type { CreateInvestmentOrderResponse } from "@/types/investment-order"
 
 interface PaymentApplicationFeeProps {
-    companyName?: string //for primary payment page
-    unitPrice?: number //for primary payment page
-    minInvestment?: number //for primary payment page
+    companyName?: string
+    unitPrice?: number
+    minInvestment?: number
+    offeringId?: number
+    offeringSlug?: string
 }
 
 const FUNDRAISER_PAYMENT_STATE_KEY = "fundraiser_application_fee_state";
 
-export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }: PaymentApplicationFeeProps) {
+export function PaymentApplicationFee({
+    companyName,
+    unitPrice,
+    minInvestment,
+    offeringId,
+}: PaymentApplicationFeeProps) {
 
     const pathName = usePathname()
     const router = useRouter();
     const { formData, updateFormData } = useOnboardingStore();
+    const { data: currentUser } = useCurrentUser();
 
-    const userId = useUserStore((state) => state.userId);
+    const tokenUserId = getUserIdFromAccessToken(tokenStorage.getAccessToken());
+    const displayUserId =
+        tokenUserId?.toString() ??
+        (currentUser?.id != null ? String(currentUser.id) : null);
 
     const [unitCount, setUnitCount] = useState(1);
     const [showError, setShowError] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [checkoutOrder, setCheckoutOrder] = useState<CreateInvestmentOrderResponse | null>(null);
 
     const [subStepIndex, setSubStepIndex] = useState(0);
     const [method, setMethod] = useState<PaymentMethod | null>(formData.paymentMethod);
@@ -83,7 +101,7 @@ export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }:
             return PAYMENT_SUBSTEPS.filter((step) => step !== "investment-summary" && step !== "success");
         }
 
-        return PAYMENT_SUBSTEPS;
+        return PAYMENT_SUBSTEPS.filter((step) => step !== "details");
     }, [isFundraiserPaymentPage]);
 
     const currentSubStep = paymentSubSteps[subStepIndex];
@@ -127,20 +145,30 @@ export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }:
             return;
         }
 
+        if (!isFundraiserPaymentPage && currentSubStep === "summary" && offeringId) {
+            try {
+                setIsSubmitting(true);
+                const order = await investmentOrderService.createOrder(offeringId, unitCount);
+                setCheckoutOrder(order);
+            } catch (error) {
+                showApiErrorToast(error, "Unable to create investment order.");
+                return;
+            } finally {
+                setIsSubmitting(false);
+            }
+        }
+
+        if (!isFundraiserPaymentPage && currentSubStep === "method") {
+            if (!method || !checkoutOrder) return;
+            await initializeInvestmentPayment(method);
+            return;
+        }
+
         if (currentSubStep === "method") {
             if (!method) return;
 
-            if (method !== "card") {
-                if (isFundraiserPaymentPage) {
-                    await finalizePayment();
-                } else {
-                    const successIndex = paymentSubSteps.indexOf("success");
-                    if (successIndex !== -1) {
-                        setSubStepIndex(successIndex);
-                    } else {
-                        setSubStepIndex(prev => prev + 1);
-                    }
-                }
+            if (isFundraiserPaymentPage && method !== "card") {
+                await finalizePayment();
                 return;
             }
         }
@@ -159,6 +187,21 @@ export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }:
             await finalizePayment();
         } else {
             setSubStepIndex(prev => prev + 1);
+        }
+    };
+
+    const initializeInvestmentPayment = async (channel: PaymentMethod) => {
+        if (!checkoutOrder) return;
+
+        try {
+            setIsSubmitting(true);
+            const session = await investmentOrderService.initializePayment(checkoutOrder.orderId, channel);
+            saveCheckoutOrderId(checkoutOrder.orderId);
+            window.location.assign(session.authorizationUrl);
+        } catch (error) {
+            showApiErrorToast(error, "Unable to start Paystack checkout.");
+        } finally {
+            setIsSubmitting(false);
         }
     };
 
@@ -212,26 +255,33 @@ export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }:
         }
     };
 
-    const unitPriceValue = unitPrice ?? 0;
-    const minInvestmentValue = minInvestment ?? 0;
+    const unitPriceValue = checkoutOrder?.sharePrice ?? unitPrice ?? 0;
+    const minInvestmentValue = checkoutOrder?.minInvestment ?? minInvestment ?? 0;
 
-    const subtotal = unitCount * unitPriceValue;
-    const platformFee = subtotal * 0.025;
-    const total = subtotal + platformFee;
+    const subtotal = checkoutOrder?.subtotal ?? unitCount * unitPriceValue;
+    const platformFee = checkoutOrder?.platformFee ?? subtotal * 0.025;
+    const total = checkoutOrder?.totalAmount ?? subtotal + platformFee;
     const isBelowMinimum = !isFundraiserPaymentPage && subtotal < minInvestmentValue;
 
     const isNextDisabled = useMemo(() => {
+        if (isSubmitting) return true;
+
         switch (currentSubStep) {
             case "method":
-                return !method;
+                return !method || (!isFundraiserPaymentPage && !checkoutOrder);
             case "details":
                 return !cardData.nameOnCard || !cardData.cardNumber || !cardData.expiry || !cardData.cvv;
             default:
                 return false;
         }
-    }, [currentSubStep, method, cardData]);
+    }, [currentSubStep, method, cardData, isSubmitting, isFundraiserPaymentPage, checkoutOrder]);
 
-    const nextLabel = currentSubStep === "details" ? "Pay" : "Next";
+    const nextLabel = useMemo(() => {
+        if (isSubmitting) return "Please wait…";
+        if (!isFundraiserPaymentPage && currentSubStep === "method") return "Pay with Paystack";
+        if (currentSubStep === "details") return "Pay";
+        return "Next";
+    }, [currentSubStep, isFundraiserPaymentPage, isSubmitting]);
 
     const backLabel = (!isFundraiserPaymentPage && subStepIndex === 0) ? "Cancel" : "Go back";
 
@@ -279,7 +329,7 @@ export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }:
                     {currentSubStep === "summary" && (
                         <PaymentSummary
                             email={formData.loginEmail}
-                            userId={userId || "No user found"}
+                            userId={displayUserId ?? "Loading…"}
                             isFundraiserPaymentPage={isFundraiserPaymentPage}
                             unitCount={unitCount}
                             setUnitCount={setUnitCount}
@@ -292,12 +342,13 @@ export function PaymentApplicationFee({ companyName, unitPrice, minInvestment }:
                     )}
                     {currentSubStep === "investment-summary" && (
                         <InvestmentPaymentSummary
-                            unitCount={unitCount}
-                            unitPrice={unitPrice!}
-                            userId={userId || "No user found"}
+                            unitCount={checkoutOrder?.units ?? unitCount}
+                            unitPrice={unitPriceValue}
+                            userId={displayUserId ?? "Loading…"}
                             formattedDate={formattedDate}
                             platformFee={platformFee}
                             totalAmount={total}
+                            subtotal={subtotal}
                         />
                     )}
                     {currentSubStep === "method" && (

--- a/src/hooks/use-investment-checkout-offering.ts
+++ b/src/hooks/use-investment-checkout-offering.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import investmentService from "@/services/investmentService";
+import type { OfferingShell } from "@/types/investment";
+
+export function useInvestmentCheckoutOffering(slug: string | null) {
+  return useQuery<OfferingShell>({
+    queryKey: ["investment-checkout-offering", slug],
+    queryFn: () => investmentService.getShell(slug!),
+    enabled: Boolean(slug),
+  });
+}

--- a/src/hooks/use-login.ts
+++ b/src/hooks/use-login.ts
@@ -10,7 +10,11 @@ import { resolvePostLoginPath } from "@/lib/post-login-navigation";
 
 export type { LoginRequest, LoginResponse };
 
-const useLogin = () => {
+export interface UseLoginOptions {
+  fromTrading?: boolean;
+}
+
+const useLogin = (options?: UseLoginOptions) => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -24,7 +28,9 @@ const useLogin = () => {
         tokenStorage.setRefreshToken(data.refreshToken, persistent);
       queryClient.invalidateQueries({ queryKey: CACHE_KEY_USER });
 
-      const path = await resolvePostLoginPath(data);
+      const path = await resolvePostLoginPath(data, {
+        fromTrading: options?.fromTrading,
+      });
       requestAnimationFrame(() => {
         router.replace(path);
       });

--- a/src/hooks/use-start-investment-checkout.ts
+++ b/src/hooks/use-start-investment-checkout.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import {
+  buildCheckoutPath,
+  buildTradingSignInPath,
+  type PendingInvestmentContext,
+} from "@/lib/investment-checkout";
+import { tokenStorage } from "@/lib/token-storage";
+
+export function useStartInvestmentCheckout() {
+  const router = useRouter();
+
+  return useCallback(
+    (context: PendingInvestmentContext) => {
+      if (tokenStorage.getAccessToken()) {
+        router.push(buildCheckoutPath(context));
+        return;
+      }
+
+      router.push(buildTradingSignInPath(context));
+    },
+    [router]
+  );
+}

--- a/src/lib/investment-checkout.ts
+++ b/src/lib/investment-checkout.ts
@@ -1,0 +1,95 @@
+export const PENDING_INVESTMENT_SESSION_KEY = "pending_investment_checkout";
+export const CHECKOUT_ORDER_ID_SESSION_KEY = "investment_checkout_order_id";
+
+export interface PendingInvestmentContext {
+  offeringId: number;
+  slug: string;
+}
+
+export function buildCheckoutPath({ offeringId, slug }: PendingInvestmentContext): string {
+  const params = new URLSearchParams({
+    offeringId: String(offeringId),
+    slug,
+  });
+  return `/marketplace/invest?${params.toString()}`;
+}
+
+export function savePendingInvestment(context: PendingInvestmentContext): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(PENDING_INVESTMENT_SESSION_KEY, JSON.stringify(context));
+}
+
+export function readPendingInvestment(): PendingInvestmentContext | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_INVESTMENT_SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PendingInvestmentContext>;
+    if (
+      typeof parsed.offeringId !== "number" ||
+      !Number.isFinite(parsed.offeringId) ||
+      typeof parsed.slug !== "string" ||
+      !parsed.slug.trim()
+    ) {
+      return null;
+    }
+    return { offeringId: parsed.offeringId, slug: parsed.slug.trim() };
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInvestment(): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(PENDING_INVESTMENT_SESSION_KEY);
+}
+
+export function buildTradingSignInPath(context: PendingInvestmentContext): string {
+  savePendingInvestment(context);
+  return "/sign-in?from=trading";
+}
+
+export function parseCheckoutSearchParams(
+  searchParams: URLSearchParams
+): PendingInvestmentContext | null {
+  const offeringIdRaw = searchParams.get("offeringId");
+  const slug = searchParams.get("slug")?.trim();
+
+  if (!offeringIdRaw || !slug) {
+    return null;
+  }
+
+  const offeringId = Number.parseInt(offeringIdRaw, 10);
+  if (!Number.isFinite(offeringId) || offeringId <= 0) {
+    return null;
+  }
+
+  return { offeringId, slug };
+}
+
+export function parseOrderIdFromPaystackReference(reference: string | null): number | null {
+  if (!reference) return null;
+  const match = /^ANT-ORD-(\d+)-/.exec(reference);
+  if (!match) return null;
+  const orderId = Number.parseInt(match[1], 10);
+  return Number.isFinite(orderId) ? orderId : null;
+}
+
+export function saveCheckoutOrderId(orderId: number): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(CHECKOUT_ORDER_ID_SESSION_KEY, String(orderId));
+}
+
+export function readCheckoutOrderId(): number | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.sessionStorage.getItem(CHECKOUT_ORDER_ID_SESSION_KEY);
+  if (!raw) return null;
+  const orderId = Number.parseInt(raw, 10);
+  return Number.isFinite(orderId) ? orderId : null;
+}
+
+export function clearCheckoutOrderId(): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(CHECKOUT_ORDER_ID_SESSION_KEY);
+}

--- a/src/lib/investment-mappers.ts
+++ b/src/lib/investment-mappers.ts
@@ -9,6 +9,8 @@ import type {
 export function toInvestmentCardData(item: InvestmentListItem): InvestmentCardData {
   return {
     id: item.slug,
+    offeringId: item.id,
+    slug: item.slug,
     name: item.name,
     category: item.category,
     description: item.tagline,

--- a/src/lib/post-login-navigation.ts
+++ b/src/lib/post-login-navigation.ts
@@ -3,6 +3,11 @@ import { ONBOARDING_CONFIG, type InvestorUserType } from "@/constants/steps";
 import onboardingService from "@/services/onboardingService";
 import { mapOnboardingStepToUiStep } from "@/lib/onboarding-hydration";
 import type { OnboardingResponse } from "@/types/onboarding";
+import {
+  buildCheckoutPath,
+  clearPendingInvestment,
+  readPendingInvestment,
+} from "@/lib/investment-checkout";
 
 /** Maps API login `userType` (camelCase or PascalCase) to onboarding URL segment. */
 export function mapLoginUserTypeToInvestorPathSegment(userType: string): InvestorUserType {
@@ -30,12 +35,20 @@ function isOnboardingCompleteStatus(status: OnboardingResponse["status"]): boole
   );
 }
 
+export interface PostLoginNavigationOptions {
+  fromTrading?: boolean;
+}
+
 /**
  * Where to send the user immediately after a successful login (tokens not yet required for this function;
  * callers must persist tokens before calling `getOnboarding` inside here).
  */
-export async function resolvePostLoginPath(login: LoginResponse): Promise<string> {
+export async function resolvePostLoginPath(
+  login: LoginResponse,
+  options?: PostLoginNavigationOptions
+): Promise<string> {
   const type = mapLoginUserTypeToInvestorPathSegment(login.userType);
+  const pendingInvestment = readPendingInvestment();
 
   if (!login.isEmailVerified) {
     return `/onboarding/${type}/email`;
@@ -44,6 +57,11 @@ export async function resolvePostLoginPath(login: LoginResponse): Promise<string
   try {
     const onboarding = await onboardingService.getOnboarding();
     if (isOnboardingCompleteStatus(onboarding.status)) {
+      if (options?.fromTrading && pendingInvestment) {
+        const checkoutPath = buildCheckoutPath(pendingInvestment);
+        clearPendingInvestment();
+        return checkoutPath;
+      }
       return "/dashboard";
     }
     const stepKey = mapOnboardingStepToUiStep(onboarding.currentStep, type);

--- a/src/services/investmentOrderService.ts
+++ b/src/services/investmentOrderService.ts
@@ -1,0 +1,70 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type {
+  CreateInvestmentOrderResponse,
+  GetInvestmentOrderResponse,
+  InitializeInvestmentPaymentResponse,
+} from "@/types/investment-order";
+import type { PaymentMethod } from "@/types/payment";
+import { toApiError } from "@/lib/api-error";
+
+async function createOrder(
+  offeringId: number,
+  units: number
+): Promise<CreateInvestmentOrderResponse> {
+  try {
+    const res = await request.post<ApiResponse<CreateInvestmentOrderResponse>>(
+      `/api/investments/${offeringId}/orders`,
+      { units }
+    );
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function getOrder(orderId: number): Promise<GetInvestmentOrderResponse> {
+  try {
+    const res = await request.get<ApiResponse<GetInvestmentOrderResponse>>(
+      `/api/investments/orders/${orderId}`
+    );
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function initializePayment(
+  orderId: number,
+  channel: PaymentMethod
+): Promise<InitializeInvestmentPaymentResponse> {
+  try {
+    const res = await request.post<ApiResponse<InitializeInvestmentPaymentResponse>>(
+      `/api/investments/orders/${orderId}/pay`,
+      { channel }
+    );
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function verifyPayment(orderId: number): Promise<GetInvestmentOrderResponse> {
+  try {
+    const res = await request.post<ApiResponse<GetInvestmentOrderResponse>>(
+      `/api/investments/orders/${orderId}/verify`
+    );
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const investmentOrderService = {
+  createOrder,
+  getOrder,
+  initializePayment,
+  verifyPayment,
+};
+
+export default investmentOrderService;

--- a/src/types/investment-order.ts
+++ b/src/types/investment-order.ts
@@ -1,0 +1,45 @@
+import type { PaymentMethod } from "@/types/payment";
+
+export interface CreateInvestmentOrderResponse {
+  orderId: number;
+  offeringId: number;
+  units: number;
+  sharePrice: number;
+  subtotal: number;
+  platformFeePercent: number;
+  platformFee: number;
+  totalAmount: number;
+  currency: string;
+  status: string;
+  minInvestment: number;
+  maxInvestment: number;
+  expiresAt: string;
+}
+
+export interface GetInvestmentOrderResponse {
+  orderId: number;
+  offeringId: number;
+  units: number;
+  sharePrice: number;
+  subtotal: number;
+  platformFeePercent: number;
+  platformFee: number;
+  totalAmount: number;
+  currency: string;
+  status: string;
+  paystackReference: string | null;
+  expiresAt: string | null;
+  paidAt: string | null;
+  investorHoldingId: number | null;
+}
+
+export interface InitializeInvestmentPaymentResponse {
+  authorizationUrl: string;
+  accessCode: string;
+  reference: string;
+  publicKey: string;
+}
+
+export function mapPaymentMethodToChannel(method: PaymentMethod): PaymentMethod {
+  return method;
+}


### PR DESCRIPTION
## Summary
- Integrates marketplace/explore invest flows with checkout APIs: create order, initialize Paystack, redirect, and callback verification/polling.
- Adds Paystack callback page and post-login return handling for interrupted checkout (`from=trading`).
- Updates primary marketplace tab to load live investment offerings from the API (landing-style cards with Invest Now).

## Test plan
- [x] Sign in as onboarded investor and start checkout from explore or marketplace
- [x] Confirm order summary and platform fee display before payment
- [x] Complete Paystack test payment and land on `/marketplace/invest/callback`
- [x] Verify success state after payment verify + order poll
- [x] Confirm marketplace primary tab shows API offerings
- [x] Confirm login redirect returns user to invest flow when `from=trading`

**Depends on:** antital-api PR for investment checkout endpoints.


Made with [Cursor](https://cursor.com)