### PR TITLE
Wire watchlist UI to live API

### DIFF
--- a/src/app/(dashboard)/watchlist/components/Watchlist.tsx
+++ b/src/app/(dashboard)/watchlist/components/Watchlist.tsx
@@ -1,82 +1,114 @@
 "use client"
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { WatchlistFilter, WatchlistCategory } from "@/components/watchlist/organisms/WatchlistFilter";
 import { TYPOGRAPHY } from "@/constants/styles";
-import { InvestmentData, RiskLevel } from "@/types/dashboard";
+import { RiskLevel } from "@/types/dashboard";
 import { WatchlistTable } from "@/components/watchlist/organisms/WatchlistTable";
-import investmentData from "@/data/dashboardInvestmentData.json"
+import { useWatchlist } from "@/hooks/use-watchlist";
+import {
+  mapWatchlistCounts,
+  mapWatchlistItemToInvestmentData,
+} from "@/lib/watchlist-mappers";
+import { showApiErrorToast } from "@/lib/error-feedback";
+import { Button } from "@/components/ui/button";
 
 export function Watchlist() {
+  const [activeCategory, setActiveCategory] = useState<WatchlistCategory>("all");
+  const [activeRisk, setActiveRisk] = useState<RiskLevel | "all">("all");
+  const [searchQuery, setSearchQuery] = useState<string>("");
 
-    const [activeCategory, setActiveCategory] = useState<WatchlistCategory>("all");
-    const [activeRisk, setActiveRisk] = useState<RiskLevel | "all">("all");
-    const [searchQuery, setSearchQuery] = useState<string>("");
+  const { data, isLoading, isError, error, refetch } = useWatchlist();
 
-    const totalCount = investmentData.length;
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, "Unable to load watchlist.");
+    }
+  }, [isError, error]);
 
-    const endingSoonCount = investmentData.filter(
-        item => item.daysLeft !== undefined && item.daysLeft < 3
-    ).length;
+  const items = useMemo(
+    () => (data?.items ?? []).map(mapWatchlistItemToInvestmentData),
+    [data?.items]
+  );
 
-    const nearTargetCount = investmentData.filter(
-        item => item.percentage !== undefined && item.percentage > 80
-    ).length;
+  const watchlistCounts = useMemo(() => {
+    if (data?.counts) {
+      return mapWatchlistCounts(data.counts);
+    }
 
-    const filteredData = investmentData.filter(item => {
-
-        if (activeCategory === "ending_soon" && (item.daysLeft === undefined || item.daysLeft >= 3)) {
-            return false;
-        }
-
-        if (activeCategory === "near_target" && (item.percentage === undefined || item.percentage <= 80)) {
-            return false;
-        }
-
-        if (activeRisk !== "all" && item.risk !== activeRisk) return false;
-
-        if (searchQuery && !item.name.toLowerCase().includes(searchQuery.toLowerCase())) return false;
-
-        return true;
-    });
-
-    const watchlistCounts = {
-        all: totalCount,
-        endingSoon: endingSoonCount,
-        nearTarget: nearTargetCount
+    return {
+      all: items.length,
+      endingSoon: items.filter((item) => item.daysLeft !== undefined && item.daysLeft < 3).length,
+      nearTarget: items.filter((item) => item.percentage !== undefined && item.percentage > 80).length,
     };
+  }, [data?.counts, items]);
 
-    return (
-        <div className="space-y-6">
+  const filteredData = items.filter((item) => {
+    if (activeCategory === "ending_soon" && (item.daysLeft === undefined || item.daysLeft >= 3)) {
+      return false;
+    }
 
-            {/* Heading Layout Section */}
-            <div className="flex flex-col gap-1 items-start">
-                <h2
-                    className="text-[24px] lg:text-[28px] text-[#1A1C1E] font-medium"
-                    style={TYPOGRAPHY.heading}
-                >
-                    Watchlist
-                </h2>
-                <p
-                    className="text-[14px] lg:text-[15px] text-[#505050]"
-                    style={TYPOGRAPHY.body}
-                >
-                    Track and manage your investment interests
-                </p>
-            </div>
+    if (activeCategory === "near_target" && (item.percentage === undefined || item.percentage <= 80)) {
+      return false;
+    }
 
-            {/* Structured Watchlist Filter Bar */}
-            <WatchlistFilter
-                activeCategory={activeCategory}
-                onCategoryChange={setActiveCategory}
-                activeRisk={activeRisk}
-                onRiskChange={setActiveRisk}
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                counts={watchlistCounts}
-            />
+    if (activeRisk !== "all" && item.risk !== activeRisk) {
+      return false;
+    }
 
-            <WatchlistTable data={filteredData as InvestmentData[]} filterType={activeCategory} />
+    if (searchQuery && !item.name.toLowerCase().includes(searchQuery.toLowerCase())) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-1 items-start">
+        <h2
+          className="text-[24px] lg:text-[28px] text-[#1A1C1E] font-medium"
+          style={TYPOGRAPHY.heading}
+        >
+          Watchlist
+        </h2>
+        <p
+          className="text-[14px] lg:text-[15px] text-[#505050]"
+          style={TYPOGRAPHY.body}
+        >
+          Track and manage your investment interests
+        </p>
+      </div>
+
+      <WatchlistFilter
+        activeCategory={activeCategory}
+        onCategoryChange={setActiveCategory}
+        activeRisk={activeRisk}
+        onRiskChange={setActiveRisk}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        counts={watchlistCounts}
+      />
+
+      {isLoading ? (
+        <p className="text-[14px] text-[#717171]" style={TYPOGRAPHY.body}>
+          Loading watchlist...
+        </p>
+      ) : isError ? (
+        <div className="flex flex-col items-center gap-3 py-8">
+          <p className="text-[14px] text-[#717171]" style={TYPOGRAPHY.body}>
+            Unable to load your watchlist.
+          </p>
+          <Button variant="outline" onClick={() => refetch()}>
+            Retry
+          </Button>
         </div>
-    );
+      ) : (
+        <WatchlistTable
+          data={filteredData}
+          filterType={activeCategory}
+        />
+      )}
+    </div>
+  );
 }

--- a/src/components/investment/organisms/investment-panel.tsx
+++ b/src/components/investment/organisms/investment-panel.tsx
@@ -1,10 +1,19 @@
+'use client'
+
 import React from 'react'
-import { Gauge, Bookmark } from 'lucide-react'
+import { Gauge, Bookmark, BookmarkCheck } from 'lucide-react'
+import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { ActionButton } from '@/components/investment/molecules/action-button'
 import type { OfferingFunding } from '@/types/investment'
 import { formatNaira, formatNumber } from '@/lib/investment-mappers'
 import { useStartInvestmentCheckout } from '@/hooks/use-start-investment-checkout'
+import {
+  useAddToWatchlist,
+  useWatchlistStatus,
+} from '@/hooks/use-watchlist'
+import { isApiErrorStatus } from '@/lib/api-error'
+import { showApiErrorToast } from '@/lib/error-feedback'
 
 interface InvestmentPanelProps {
   offeringId: number
@@ -14,10 +23,41 @@ interface InvestmentPanelProps {
 
 export function InvestmentPanel({ offeringId, slug, funding }: InvestmentPanelProps) {
   const startCheckout = useStartInvestmentCheckout()
+  const { data: status, isLoading: isStatusLoading } = useWatchlistStatus(offeringId)
+  const addToWatchlist = useAddToWatchlist()
+
+  const isWatchlisted = status?.isWatchlisted ?? false
 
   const handleStartTrading = () => {
     startCheckout({ offeringId, slug })
   }
+
+  const handleAddToWatchlist = () => {
+    if (isWatchlisted || addToWatchlist.isPending) {
+      return
+    }
+
+    addToWatchlist.mutate(offeringId, {
+      onSuccess: () => {
+        toast.success('Added to watchlist')
+      },
+      onError: (error) => {
+        if (isApiErrorStatus(error, 409)) {
+          toast.error('Already on your watchlist')
+          return
+        }
+        showApiErrorToast(error, 'Unable to add to watchlist.')
+      },
+    })
+  }
+
+  const watchlistLabel = isStatusLoading
+    ? 'Checking watchlist...'
+    : isWatchlisted
+      ? 'On watchlist'
+      : addToWatchlist.isPending
+        ? 'Adding...'
+        : 'Add to watchlist'
 
   return (
     <div className="w-full max-w-full lg:w-auto lg:max-w-[400px]">
@@ -87,12 +127,13 @@ export function InvestmentPanel({ offeringId, slug, funding }: InvestmentPanelPr
               onClick={handleStartTrading}
             />
             <ActionButton
-              text="Add to watchlist"
+              text={watchlistLabel}
               variant="outline"
-              icon={Bookmark}
+              icon={isWatchlisted ? BookmarkCheck : Bookmark}
               iconPosition="left"
               width="100%"
               height="48px"
+              onClick={isWatchlisted || isStatusLoading ? undefined : handleAddToWatchlist}
             />
           </div>
         </div>

--- a/src/components/watchlist/organisms/WatchlistTable.tsx
+++ b/src/components/watchlist/organisms/WatchlistTable.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from "@/constants/styles";
 import {
     AlertTriangle,
@@ -15,6 +17,8 @@ import { SetReminderModal } from '@/components/watchlist/organisms/SetReminderMo
 import { ReminderSuccessModal } from '@/components/watchlist/organisms/ReminderSuccessModal';
 import { WatchlistEmptyState, WatchlistFilterType } from '@/components/watchlist/organisms/WatchlistEmptyState';
 import { TablePagination } from '@/components/watchlist/molecules/TablePagination';
+import { useRemoveFromWatchlist } from '@/hooks/use-watchlist';
+import { showApiErrorToast } from '@/lib/error-feedback';
 
 interface WatchlistTableProps {
     data: InvestmentData[];
@@ -23,6 +27,8 @@ interface WatchlistTableProps {
 }
 
 export function WatchlistTable({ data, filterType, itemsPerPage = 10 }: WatchlistTableProps) {
+    const router = useRouter();
+    const removeFromWatchlist = useRemoveFromWatchlist();
     const [currentPage, setCurrentPage] = useState(1);
 
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -75,6 +81,28 @@ export function WatchlistTable({ data, filterType, itemsPerPage = 10 }: Watchlis
         setIsFormOpen(false);
         setIsSuccessOpen(false);
         setActiveItem(null);
+    };
+
+    const handleViewProject = (item: InvestmentData) => {
+        const target = item.slug ?? item.id;
+        router.push(`/explore/${target}`);
+    };
+
+    const handleRemoveFromWatchlist = (item: InvestmentData) => {
+        const offeringId = Number(item.id);
+        if (!Number.isFinite(offeringId)) {
+            return;
+        }
+
+        removeFromWatchlist.mutate(offeringId, {
+            onSuccess: () => {
+                toast.success(`${item.name} removed from watchlist`);
+                setSelectedIds((prev) => prev.filter((id) => id !== item.id));
+            },
+            onError: (error) => {
+                showApiErrorToast(error, "Unable to remove from watchlist.");
+            },
+        });
     };
 
     return (
@@ -170,7 +198,9 @@ export function WatchlistTable({ data, filterType, itemsPerPage = 10 }: Watchlis
                                             <td className="py-1">
                                                 <div className="flex items-center gap-2 text-[#1A1C1E] text-[14px]">
                                                     <Clock className="w-4 h-4 text-[#1A1C1E]" />
-                                                    <span style={TYPOGRAPHY.body}>{item.daysLeft} days</span>
+                                                    <span style={TYPOGRAPHY.body}>
+                                                        {item.daysLeft !== undefined ? `${item.daysLeft} days` : '—'}
+                                                    </span>
                                                 </div>
                                             </td>
 
@@ -201,10 +231,21 @@ export function WatchlistTable({ data, filterType, itemsPerPage = 10 }: Watchlis
                                                     >
                                                         <AlarmClock className="w-4 h-4" />
                                                     </button>
-                                                    <button className="hover:text-black transition-colors cursor-pointer">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleViewProject(item)}
+                                                        className="hover:text-black transition-colors cursor-pointer"
+                                                        aria-label={`View ${item.name}`}
+                                                    >
                                                         <Eye className="w-4 h-4" />
                                                     </button>
-                                                    <button className="hover:text-black transition-colors cursor-pointer">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleRemoveFromWatchlist(item)}
+                                                        disabled={removeFromWatchlist.isPending}
+                                                        className="hover:text-black transition-colors cursor-pointer disabled:opacity-50"
+                                                        aria-label={`Remove ${item.name} from watchlist`}
+                                                    >
                                                         <Bookmark className="w-4 h-4 text-[#1A1C1E]" />
                                                     </button>
                                                 </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const CACHE_KEY_INVESTMENTS = ["investments"] as const;
 export const CACHE_KEY_DASHBOARD = ["dashboard"] as const;
 export const CACHE_KEY_WALLET_TRANSACTIONS = ["wallet-transactions"] as const;
 export const CACHE_KEY_PAYMENT_METHODS = ["payment-methods"] as const;
+export const CACHE_KEY_WATCHLIST = ["watchlist"] as const;
 
 export const ACCESS_TOKEN_KEY = "access_token";
 export const REFRESH_TOKEN_KEY = "refresh_token";

--- a/src/hooks/use-watchlist.ts
+++ b/src/hooks/use-watchlist.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CACHE_KEY_WATCHLIST } from "@/constants";
+import watchlistService from "@/services/watchlistService";
+
+export function useWatchlist() {
+  return useQuery({
+    queryKey: CACHE_KEY_WATCHLIST,
+    queryFn: () => watchlistService.getWatchlist(),
+  });
+}
+
+export function useWatchlistStatus(offeringId: number, enabled = true) {
+  return useQuery({
+    queryKey: [...CACHE_KEY_WATCHLIST, "status", offeringId],
+    queryFn: () => watchlistService.getWatchlistStatus(offeringId),
+    enabled: enabled && offeringId > 0,
+  });
+}
+
+export function useAddToWatchlist() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (offeringId: number) => watchlistService.addToWatchlist(offeringId),
+    onSuccess: (_data, offeringId) => {
+      queryClient.invalidateQueries({ queryKey: CACHE_KEY_WATCHLIST });
+      queryClient.invalidateQueries({
+        queryKey: [...CACHE_KEY_WATCHLIST, "status", offeringId],
+      });
+    },
+  });
+}
+
+export function useRemoveFromWatchlist() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (offeringId: number) => watchlistService.removeFromWatchlist(offeringId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CACHE_KEY_WATCHLIST });
+    },
+  });
+}

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -16,16 +16,19 @@ type ApiEnvelopeLike = {
 export class ApiError extends Error {
   readonly errors: string[];
   readonly validationErrors: Record<string, string[]>;
+  readonly status?: number;
 
   constructor(
     message: string,
     errors: string[] = [],
-    validationErrors: Record<string, string[]> = {}
+    validationErrors: Record<string, string[]> = {},
+    status?: number
   ) {
     super(message);
     this.name = "ApiError";
     this.errors = errors;
     this.validationErrors = validationErrors;
+    this.status = status;
     Object.setPrototypeOf(this, ApiError.prototype);
   }
 
@@ -79,6 +82,7 @@ export function toApiError(error: unknown): Error {
   if (error instanceof ApiError) return error;
 
   if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
     const envelope = readEnvelope(error.response?.data);
     if (envelope) {
       const validationErrors = envelope.validationErrors ?? {};
@@ -91,9 +95,9 @@ export function toApiError(error: unknown): Error {
         envelope.title ??
         error.message;
 
-      return new ApiError(message, errors, validationErrors);
+      return new ApiError(message, errors, validationErrors, status);
     }
-    return new Error(error.message);
+    return new ApiError(error.message, [], {}, status);
   }
 
   if (error instanceof Error) return error;
@@ -117,4 +121,9 @@ export function getApiPrimaryMessage(
   fallback = "Request failed"
 ): string {
   return getApiErrorMessages(error, fallback)[0] ?? fallback;
+}
+
+export function isApiErrorStatus(error: unknown, status: number): boolean {
+  const normalized = toApiError(error);
+  return normalized instanceof ApiError && normalized.status === status;
 }

--- a/src/lib/watchlist-mappers.ts
+++ b/src/lib/watchlist-mappers.ts
@@ -1,0 +1,77 @@
+import type { InvestmentData, RiskLevel } from "@/types/dashboard";
+import type { WatchlistCounts, WatchlistItem } from "@/types/watchlist";
+
+function parseRisk(risk: string): Exclude<RiskLevel, "All Risk"> {
+  const normalized = risk.trim().toLowerCase();
+  if (normalized === "low" || normalized === "moderate" || normalized === "high") {
+    return normalized;
+  }
+  return "moderate";
+}
+
+export function formatWatchlistAddedDate(addedAt: string): string {
+  const date = new Date(addedAt);
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = date.getFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+export function formatUpdateTimeAgo(recentUpdateAt?: string | null): string | undefined {
+  if (!recentUpdateAt) {
+    return undefined;
+  }
+
+  const diffMs = Date.now() - new Date(recentUpdateAt).getTime();
+  if (diffMs < 0) {
+    return "just now";
+  }
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) {
+    return "just now";
+  }
+  if (minutes < 60) {
+    return minutes === 1 ? "1 minute ago" : `${minutes} minutes ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return hours === 1 ? "1 hour ago" : `${hours} hours ago`;
+  }
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) {
+    return days === 1 ? "1 day ago" : `${days} days ago`;
+  }
+
+  const weeks = Math.floor(days / 7);
+  return weeks === 1 ? "1 week ago" : `${weeks} weeks ago`;
+}
+
+export function mapWatchlistItemToInvestmentData(item: WatchlistItem): InvestmentData {
+  return {
+    id: String(item.offeringId),
+    slug: item.slug,
+    name: item.name,
+    category: item.sector,
+    sector: item.sector,
+    risk: parseRisk(item.risk),
+    daysLeft: item.daysLeft ?? undefined,
+    percentage: item.fundingProgressPercent,
+    priceChange: item.changePercent,
+    watchlistAddedDate: formatWatchlistAddedDate(item.addedAt),
+    recentUpdate: item.recentUpdate ?? undefined,
+    updateTimeAgo: formatUpdateTimeAgo(item.recentUpdateAt),
+    remindersCount: item.remindersCount,
+    isWatched: true,
+  };
+}
+
+export function mapWatchlistCounts(counts: WatchlistCounts) {
+  return {
+    all: counts.all,
+    endingSoon: counts.endingSoon,
+    nearTarget: counts.nearTarget,
+  };
+}

--- a/src/services/watchlistService.ts
+++ b/src/services/watchlistService.ts
@@ -1,0 +1,60 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type {
+  AddToWatchlistRequest,
+  WatchlistItem,
+  WatchlistResponse,
+  WatchlistStatusResponse,
+} from "@/types/watchlist";
+import { toApiError } from "@/lib/api-error";
+
+const BASE = "/api/investors/me/watchlist";
+
+async function getWatchlist(): Promise<WatchlistResponse> {
+  try {
+    const res = await request.get<ApiResponse<WatchlistResponse>>(BASE);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function addToWatchlist(offeringId: number): Promise<WatchlistItem> {
+  try {
+    const payload: AddToWatchlistRequest = { offeringId };
+    const res = await request.post<ApiResponse<WatchlistItem>>(BASE, payload);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function removeFromWatchlist(offeringId: number): Promise<void> {
+  try {
+    const res = await request.delete<ApiResponse<unknown>>(`${BASE}/${offeringId}`);
+    unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function getWatchlistStatus(offeringId: number): Promise<WatchlistStatusResponse> {
+  try {
+    const res = await request.get<ApiResponse<WatchlistStatusResponse>>(
+      `${BASE}/status`,
+      { params: { offeringId } }
+    );
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const watchlistService = {
+  getWatchlist,
+  addToWatchlist,
+  removeFromWatchlist,
+  getWatchlistStatus,
+};
+
+export default watchlistService;

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,6 +1,7 @@
 export interface InvestmentData {
     // --- Identity & Meta ---
     id: string;
+    slug?: string;
     name: string;
     category: string;
     sector: string;

--- a/src/types/watchlist.ts
+++ b/src/types/watchlist.ts
@@ -1,0 +1,33 @@
+export interface WatchlistItem {
+  offeringId: number;
+  slug: string;
+  name: string;
+  sector: string;
+  risk: string;
+  daysLeft: number | null;
+  fundingProgressPercent: number;
+  changePercent: number;
+  addedAt: string;
+  recentUpdate: string | null;
+  recentUpdateAt: string | null;
+  remindersCount: number;
+}
+
+export interface WatchlistCounts {
+  all: number;
+  endingSoon: number;
+  nearTarget: number;
+}
+
+export interface WatchlistResponse {
+  items: WatchlistItem[];
+  counts: WatchlistCounts;
+}
+
+export interface AddToWatchlistRequest {
+  offeringId: number;
+}
+
+export interface WatchlistStatusResponse {
+  isWatchlisted: boolean;
+}


### PR DESCRIPTION
## Summary
- Replace mock watchlist data with live investor watchlist API integration on the watchlist page and investment detail panel.
- Add `watchlistService`, React Query hooks, and mappers for list/status/add/remove flows.
- Preserve HTTP status on `ApiError` so duplicate add-to-watchlist shows the correct 409 toast.

## Depends on
- API PR: BloydIntel/antital-api (watchlist endpoints) — merge and deploy before full staging verification.

## Test plan
- [x] Type-check and production build pass locally
- [x] Local E2E via Aspire: list tabs/counts, add from explore page, remove from watchlist table
- [x] Staging smoke test after API deploy


Made with [Cursor](https://cursor.com)