### PR TITLE
Wire settings UI to live profile, account, and security APIs

### DIFF
--- a/src/app/(dashboard)/settings/components/Settings.tsx
+++ b/src/app/(dashboard)/settings/components/Settings.tsx
@@ -8,12 +8,21 @@ import { Profile } from '@/components/settings/organisms/Profile';
 import { Security } from '@/components/settings/organisms/Security';
 import { SettingsPillTab } from '@/components/settings/organisms/SettingsPillTab'
 import { TYPOGRAPHY } from '@/constants/styles'
+import { useInvestorAccount } from '@/hooks/use-settings';
+import authService from '@/services/authService';
+import { getUserIdFromAccessToken } from '@/lib/jwt';
+import { tokenStorage } from '@/lib/token-storage';
+import { showApiErrorToast } from '@/lib/error-feedback';
+import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner';
 
 export function Settings() {
+    const router = useRouter();
     const searchParams = useSearchParams();
     const tabParam = searchParams.get('tab');
+    const { data: account, isLoading: isAccountLoading } = useInvestorAccount();
 
     const [activeTab, setActiveTab] = useState(() => tabParam || "profile");
 
@@ -22,6 +31,23 @@ export function Settings() {
             setActiveTab(tabParam);
         }
     }, [tabParam]);
+
+    const handleDeleteAccount = useCallback(async () => {
+        const userId = getUserIdFromAccessToken(tokenStorage.getAccessToken());
+        if (userId == null) {
+            throw new Error('Unable to determine user id.');
+        }
+
+        try {
+            await authService.deleteAccount(userId);
+            tokenStorage.clear();
+            toast.success('Account deleted');
+            router.push('/sign-in');
+        } catch (error) {
+            showApiErrorToast(error, 'Unable to delete account.');
+            throw error;
+        }
+    }, [router]);
 
     const renderTabContent = () => {
         switch (activeTab) {
@@ -36,7 +62,7 @@ export function Settings() {
             case "payment":
                 return <PaymentMethodsSettings />
             case "preferences":
-                return <Preferences />
+                return <Preferences onDeleteAccount={handleDeleteAccount} />
             default:
                 return null;
         }
@@ -53,7 +79,7 @@ export function Settings() {
                     </p>
                 </div>
                 <span className="hidden lg:block text-[16px] text-[#1F1F1F] bg-[#FFFFFF] border border-[#EAEAEA] rounded-lg px-2 py-1.5" style={TYPOGRAPHY.heading}>
-                    Ordinary Investor
+                    {isAccountLoading ? 'Loading...' : account?.accountType ?? 'Ordinary Investor'}
                 </span>
             </div>
             <SettingsPillTab activeTab={activeTab} onTabChange={setActiveTab} />

--- a/src/components/command-search.tsx
+++ b/src/components/command-search.tsx
@@ -153,12 +153,12 @@ export function CommandSearch({ open, onOpenChange }: CommandSearchProps) {
     { title: "Under Maintenance", url: "/errors/under-maintenance", group: "Errors", icon: AlertTriangle },
 
     // Settings
-    { title: "User Settings", url: "/settings/user", group: "Settings", icon: User },
-    { title: "Account Settings", url: "/settings/account", group: "Settings", icon: Settings },
-    { title: "Plans & Billing", url: "/settings/billing", group: "Settings", icon: CreditCard },
-    { title: "Appearance", url: "/settings/appearance", group: "Settings", icon: Palette },
-    { title: "Notifications", url: "/settings/notifications", group: "Settings", icon: Bell },
-    { title: "Connections", url: "/settings/connections", group: "Settings", icon: Link2 },
+    { title: "User Settings", url: "/settings?tab=profile", group: "Settings", icon: User },
+    { title: "Account Settings", url: "/settings?tab=account", group: "Settings", icon: Settings },
+    { title: "Plans & Billing", url: "/settings?tab=payment", group: "Settings", icon: CreditCard },
+    { title: "Appearance", url: "/settings?tab=preferences", group: "Settings", icon: Palette },
+    { title: "Notifications", url: "/settings?tab=notification", group: "Settings", icon: Bell },
+    { title: "Connections", url: "/settings", group: "Settings", icon: Link2 },
 
     // Pages
     { title: "FAQs", url: "/faqs", group: "Pages", icon: HelpCircle },

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -82,19 +82,19 @@ export function NavUser({
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem asChild className="cursor-pointer">
-                <Link href="/settings/account">
+                <Link href="/settings?tab=account">
                   <CircleUser />
                   Account
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild className="cursor-pointer">
-                <Link href="/settings/billing">
+                <Link href="/settings?tab=payment">
                   <CreditCard />
                   Billing
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild className="cursor-pointer">
-                <Link href="/settings/notifications">
+                <Link href="/settings?tab=notification">
                   <BellDot />
                   Notifications
                 </Link>

--- a/src/components/settings/organisms/Account.tsx
+++ b/src/components/settings/organisms/Account.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { User, CheckCircle2, FileText, RefreshCw } from 'lucide-react';
 import { TYPOGRAPHY } from "@/constants/styles";
+import { useInvestorAccount } from '@/hooks/use-settings';
+import {
+  mapAccountCompliance,
+  mapAccountLimits,
+  mapAccountToProfile,
+} from '@/lib/settings-mappers';
+import { showApiErrorToast } from '@/lib/error-feedback';
 
 export interface AccountDataProfile {
     accountType: string;
@@ -29,46 +36,95 @@ export interface ComplianceCheckItem {
 }
 
 interface AccountProps {
-    profile?: AccountDataProfile;
-    limits?: InvestmentLimitsMetrics;
-    compliance?: ComplianceCheckItem[];
     onViewKYC?: () => void;
     onRequestUpgrade?: () => void;
 }
 
-// ==================== MOCK FALLBACK DATA ====================
-// This automatically provides safety data if your API response is loading or blank
-const defaultProfile: AccountDataProfile = {
-    accountType: "Ordinary Investor",
-    accountStatus: "Active",
-    kycStatus: "Completed",
-    kycCompletedDate: "10/1/2024",
-    investorClassification: "Ordinary",
-    verificationStatus: "Verified",
-    memberSince: "9/15/2024",
-    riskRating: "Low"
-};
-
-const defaultLimits: InvestmentLimitsMetrics = {
-    annualLimit: 5000000,
-    usedPercentage: 60,
-    perProjectLimit: 1000000,
-    lifetimeLimit: 20000000,
-};
-
-const defaultCompliance: ComplianceCheckItem[] = [
-    { id: 'aml', label: 'Anti-Money Laundering Check', status: 'Passed' },
-    { id: 'sanctions', label: 'Sanctions Screening', status: 'Clear' },
-    { id: 'pep', label: 'Politically Exposed Person', status: 'Not Applicable' }
-];
-
 export function Account({
-    profile = defaultProfile,
-    limits = defaultLimits,
-    compliance = defaultCompliance,
     onViewKYC,
     onRequestUpgrade
 }: AccountProps) {
+    const { data: account, isLoading, isError, error } = useInvestorAccount();
+
+    useEffect(() => {
+        if (isError) {
+            showApiErrorToast(error, 'Unable to load account information.');
+        }
+    }, [isError, error]);
+
+    const profile = useMemo(
+        () => (account ? mapAccountToProfile(account) : null),
+        [account]
+    );
+    const limits = useMemo(
+        () => (account ? mapAccountLimits(account) : null),
+        [account]
+    );
+    const compliance = useMemo(
+        () => (account ? mapAccountCompliance(account) : []),
+        [account]
+    );
+
+    const informationGridItems = useMemo(() => {
+        if (!profile) {
+            return [];
+        }
+
+        return [
+            {
+                label: "Account Type",
+                value: profile.accountType,
+                badge: profile.accountStatus
+            },
+            {
+                label: "KYC Status",
+                value: profile.kycStatus,
+                badge: profile.kycStatus,
+                subtext: profile.kycStatus === 'Completed' && profile.kycCompletedDate
+                    ? `Completed: ${profile.kycCompletedDate}`
+                    : undefined,
+                showIcon: profile.kycStatus === 'Completed'
+            },
+            {
+                label: "Investor Classification",
+                value: profile.investorClassification
+            },
+            {
+                label: "Verification Status",
+                value: profile.verificationStatus,
+                badge: profile.verificationStatus,
+                showIcon: profile.verificationStatus === 'Verified'
+            },
+            {
+                label: "Member Since",
+                value: profile.memberSince
+            },
+            {
+                label: "Risk Rating",
+                badge: profile.riskRating
+            }
+        ];
+    }, [profile]);
+
+    if (isLoading) {
+        return (
+            <div className="w-full">
+                <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+                    Loading account information...
+                </p>
+            </div>
+        );
+    }
+
+    if (!profile || !limits) {
+        return (
+            <div className="w-full">
+                <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+                    Unable to load account information.
+                </p>
+            </div>
+        );
+    }
 
     // Formatter utility for Nigerian Naira
     const formatNaira = (value: number) => {
@@ -102,40 +158,6 @@ export function Account({
                 return 'bg-[#F4F5F7] text-[#505050] border border-[#EAEAEA]';
         }
     };
-
-    // Dynamic data representation map for rendering Section 1 loops cleanly
-    const informationGridItems = useMemo(() => [
-        {
-            label: "Account Type",
-            value: profile.accountType,
-            badge: profile.accountStatus
-        },
-        {
-            label: "KYC Status",
-            value: profile.kycStatus,
-            badge: profile.kycStatus,
-            subtext: `Completed: ${profile.kycCompletedDate}`,
-            showIcon: profile.kycStatus === 'Completed'
-        },
-        {
-            label: "Investor Classification",
-            value: profile.investorClassification
-        },
-        {
-            label: "Verification Status",
-            value: profile.verificationStatus,
-            badge: profile.verificationStatus,
-            showIcon: profile.verificationStatus === 'Verified'
-        },
-        {
-            label: "Member Since",
-            value: profile.memberSince
-        },
-        {
-            label: "Risk Rating",
-            badge: profile.riskRating
-        }
-    ], [profile]);
 
     return (
         <div className="w-full">

--- a/src/components/settings/organisms/Preferences.tsx
+++ b/src/components/settings/organisms/Preferences.tsx
@@ -92,10 +92,16 @@ export function Preferences({
     };
 
     const handleConfirmDeletion = async () => {
-        if (onDeleteAccount) {
-            await onDeleteAccount();
+        if (!onDeleteAccount) {
+            return;
         }
-        setIsModalOpen(false);
+
+        try {
+            await onDeleteAccount();
+            setIsModalOpen(false);
+        } catch {
+            // Keep modal open; DeleteAccountModal resets submitting state.
+        }
     };
 
     return (

--- a/src/components/settings/organisms/Profile.tsx
+++ b/src/components/settings/organisms/Profile.tsx
@@ -2,244 +2,264 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { User, MapPin, Save, Pencil, Camera } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from "@/constants/styles";
 import { OnboardingInput } from '@/components/onboarding/molecules/OnboardingInput';
-import { useUserStore } from '@/store/userStore';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton';
+import { useInvestorProfile, useUpdateInvestorProfile } from '@/hooks/use-settings';
+import {
+  mapFormDataToUpdateRequest,
+  mapProfileToFormData,
+  type ProfileFormData,
+} from '@/lib/settings-mappers';
+import { showApiErrorToast } from '@/lib/error-feedback';
+
+const EMPTY_FORM: ProfileFormData = {
+  firstName: '',
+  lastName: '',
+  userId: '',
+  emailAddress: '',
+  phoneNumber: '',
+  streetAddress: '',
+  city: '',
+  state: '',
+  profilePictureUrl: '/dashboard/User-Avatar.png',
+};
 
 export function Profile() {
-    const store = useUserStore();
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const objectUrlRef = useRef<string | null>(null);
+  const { data: profile, isLoading, isError, error } = useInvestorProfile();
+  const updateProfile = useUpdateInvestorProfile();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const objectUrlRef = useRef<string | null>(null);
 
-    // Local form state
-    const [formData, setFormData] = useState({
-        firstName: 'John',
-        lastName: 'Doe',
-        userId: 'h3u4viwj3bu4viwbwhb3hv4',
-        emailAddress: 'johnndoe@gmail.com',
-        streetAddress: '15 Victoria Island Avenue',
-        city: 'Lagos',
-        state: 'Lagos State',
-        profilePictureUrl: '/dashboard/User-Avatar.png'
+  const [formData, setFormData] = useState<ProfileFormData>(EMPTY_FORM);
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, 'Unable to load profile.');
+    }
+  }, [isError, error]);
+
+  useEffect(() => {
+    if (profile && !isEditing) {
+      setFormData(mapProfileToFormData(profile));
+    }
+  }, [profile, isEditing]);
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+      }
+    };
+  }, []);
+
+  const handleInputChange = useCallback((name: keyof ProfileFormData, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  }, []);
+
+  const handleSaveChanges = () => {
+    if (!profile) {
+      return;
+    }
+
+    updateProfile.mutate(mapFormDataToUpdateRequest(formData, profile), {
+      onSuccess: () => {
+        toast.success('Profile updated');
+        setIsEditing(false);
+      },
+      onError: (saveError) => {
+        showApiErrorToast(saveError, 'Unable to update profile.');
+      },
     });
+  };
 
-    const [isEditing, setIsEditing] = useState(false);
+  const handleCancel = () => {
+    if (profile) {
+      setFormData(mapProfileToFormData(profile));
+    }
+    setIsEditing(false);
+  };
 
-    // Cleanup object URL on unmount to prevent memory leaks
-    useEffect(() => {
-        return () => {
-            if (objectUrlRef.current) {
-                URL.revokeObjectURL(objectUrlRef.current);
-            }
-        };
-    }, []);
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (file.size > 5 * 1024 * 1024) {
+        toast.error('File size looks too large! Please choose an image up to 5MB.');
+        return;
+      }
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+      }
+      const localUrl = URL.createObjectURL(file);
+      objectUrlRef.current = localUrl;
+      handleInputChange('profilePictureUrl', localUrl);
+    }
+  }, [handleInputChange]);
 
-    // Sync store data with fallback values safely after hydration
-    useEffect(() => {
-        setFormData({
-            firstName: store.firstName || 'John',
-            lastName: store.lastName || 'Doe',
-            userId: store.userId || 'h3u4viwj3bu4viwbwhb3hv4',
-            emailAddress: store.emailAddress || 'johnndoe@gmail.com',
-            streetAddress: store.streetAddress || '15 Victoria Island Avenue',
-            city: store.city || 'Lagos',
-            state: store.state || 'Lagos State',
-            profilePictureUrl: store.profilePictureUrl || '/dashboard/User-Avatar.png'
-        });
-    }, [store.firstName, store.lastName, store.userId, store.emailAddress, store.streetAddress, store.city, store.state, store.profilePictureUrl]);
+  const initials = `${formData.firstName.charAt(0)}${formData.lastName.charAt(0)}`.trim() || 'U';
 
-    const handleInputChange = useCallback((name: keyof typeof formData, value: string) => {
-        setFormData((prev) => ({
-            ...prev,
-            [name]: value,
-        }));
-    }, []);
-
-    const handleSaveChanges = () => {
-        store.updateProfile({
-            firstName: formData.firstName,
-            lastName: formData.lastName,
-            emailAddress: formData.emailAddress,
-            streetAddress: formData.streetAddress,
-            city: formData.city,
-            state: formData.state,
-            profilePictureUrl: formData.profilePictureUrl
-        });
-        setIsEditing(false);
-    };
-
-    const handleCancel = () => {
-        setFormData({
-            firstName: store.firstName || 'John',
-            lastName: store.lastName || 'Doe',
-            userId: store.userId || 'h3u4viwj3bu4viwbwhb3hv4',
-            emailAddress: store.emailAddress || 'johnndoe@gmail.com',
-            streetAddress: store.streetAddress || '15 Victoria Island Avenue',
-            city: store.city || 'Lagos',
-            state: store.state || 'Lagos State',
-            profilePictureUrl: store.profilePictureUrl || '/dashboard/User-Avatar.png'
-        });
-        setIsEditing(false);
-    };
-
-    const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (file) {
-            if (file.size > 5 * 1024 * 1024) {
-                alert("File size looks too large! Please choose an image up to 5MB.");
-                return;
-            }
-            // Revoke previous object URL to prevent memory leaks
-            if (objectUrlRef.current) {
-                URL.revokeObjectURL(objectUrlRef.current);
-            }
-            // Generate a local preview URL
-            const localUrl = URL.createObjectURL(file);
-            objectUrlRef.current = localUrl;
-            handleInputChange('profilePictureUrl', localUrl);
-        }
-    }, [handleInputChange]);
-
+  if (isLoading) {
     return (
-        <div className="w-full mx-auto rounded-xl">
-            {/* Header Layout Control Block */}
-            <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between mb-8">
-                <div className="flex flex-col gap-1">
-
-                    <div className="flex items-center gap-2">
-                        <User className="w-4 h-4 text-[#1A1A1A]" fill="#1A1A1A" stroke="#1A1A1A" />
-                        <h2 className="text-[18px] lg:text-[20px] text-[#1A1A1A]" style={TYPOGRAPHY.body}>
-                            Personal Information
-                        </h2>
-                    </div>
-
-                    <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
-                        Update your personal details and profile
-                    </p>
-
-                </div>
-
-                <div className='flex justify-end'>
-                    <OnboardingButton
-                        label={isEditing ? 'Save Changes' : 'Edit Profile'}
-                        icon={isEditing ? <Save size={18} /> : <Pencil size={18} />}
-                        variant={isEditing ? 'solid' : 'plain'}
-                        onClick={isEditing ? handleSaveChanges : () => setIsEditing(true)}
-                        className={`mt-0 mb-0 border-none ${isEditing ? 'max-w-[167px]' : 'bg-white max-w-[139px]'}`}
-                    />
-                </div>
-            </div>
-
-            {/* Profile Avatar Frame Container */}
-            <div className="flex items-center gap-4 mb-6">
-                <Avatar className="h-18 w-18 border border-[#EAEAEA]">
-                    <AvatarImage src={formData.profilePictureUrl} alt="User Profile" className="object-cover" />
-                    <AvatarFallback>JD</AvatarFallback>
-                </Avatar>
-
-                {isEditing && (
-                    <div className="flex flex-col gap-2 items-start">
-                        <input
-                            type="file"
-                            ref={fileInputRef}
-                            onChange={handleFileChange}
-                            accept="image/png, image/jpeg"
-                            className="hidden"
-                        />
-                        <button
-                            type="button"
-                            onClick={() => fileInputRef.current?.click()}
-                            className="flex items-center gap-2 px-4 py-2 border border-[#EAEAEA] rounded-lg bg-white text-[#1A1A1A] text-[14px] font-medium shadow-sm hover:bg-gray-50 transition-colors cursor-pointer"
-                            style={TYPOGRAPHY.heading}
-                        >
-                            <Camera size={16} className="text-[#1A1A1A]" />
-                            <span>Change Photo</span>
-                        </button>
-                        <span className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
-                            JPG, PNG up to 5MB
-                        </span>
-                    </div>
-                )}
-            </div>
-
-            {/* Personal Info Input Data Grid Structure */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
-                {(
-                    [
-                        { id: 'firstName', label: 'First Name', placeholder: 'Enter first name' },
-                        { id: 'lastName', label: 'Last Name', placeholder: 'Enter last name' },
-                        { id: 'userId', label: 'User ID', placeholder: 'Enter user id', alwaysDisabled: true },
-                        { id: 'emailAddress', label: 'Email Address', placeholder: 'Enter email address' },
-                    ] as Array<{ id: keyof typeof formData; label: string; placeholder: string; alwaysDisabled?: boolean }>
-                ).map(({ id, label, placeholder, alwaysDisabled }) => (
-                    <OnboardingInput
-                        key={id}
-                        label={label}
-                        placeholder={placeholder}
-                        value={formData[id]}
-                        disabled={alwaysDisabled || !isEditing}
-                        onChange={(e) => handleInputChange(id, e.target.value)}
-                        inputAreaStyle='bg-[#FFFFFF] text-[16px] text-[#858585]'
-                    />
-                ))}
-            </div>
-
-            {/* Address Group Sub-Header Section */}
-            <div className="flex items-center gap-3 mt-8 mb-6 border-t border-[#F4F5F7]">
-                <MapPin className="w-5 h-5 text-[#1A1A1A]" />
-                <h3 className="text-[16px] lg:text-[20px] text-[#1A1A1A]" style={TYPOGRAPHY.body}>
-                    Address Information
-                </h3>
-            </div>
-
-            {/* Full Width Line Input followed by Split Grid */}
-            <div className="w-full mb-2">
-                <OnboardingInput
-                    label="Street Address"
-                    placeholder="Enter street address"
-                    value={formData.streetAddress}
-                    disabled={!isEditing}
-                    onChange={(e) => handleInputChange('streetAddress', e.target.value)}
-                    inputAreaStyle='bg-[#FFFFFF] text-[16px] text-[#858585]'
-
-                />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
-                {(
-                    [
-                        { id: 'city', label: 'City', placeholder: 'Enter city' },
-                        { id: 'state', label: 'State', placeholder: 'Enter state' },
-                    ] as const
-                ).map(({ id, label, placeholder }) => (
-                    <OnboardingInput
-                        key={id}
-                        label={label}
-                        placeholder={placeholder}
-                        value={formData[id]}
-                        disabled={!isEditing}
-                        onChange={(e) => handleInputChange(id, e.target.value)}
-                        inputAreaStyle='bg-[#FFFFFF] text-[16px] text-[#858585]'
-                    />
-                ))}
-            </div>
-            {isEditing && <div className="flex flex-row gap-2 justify-end">
-                <OnboardingButton
-                    label='Save Changes'
-                    icon={<Save size={18} />}
-                    variant="solid"
-                    onClick={handleSaveChanges}
-                    className="max-w-[157px]"
-                />
-                <OnboardingButton
-                    label='Cancel'
-                    variant="plain"
-                    onClick={handleCancel}
-                    className="max-w-[115px]"
-                />
-            </div>}
-        </div>
+      <div className="w-full mx-auto rounded-xl">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Loading profile...
+        </p>
+      </div>
     );
+  }
+
+  if (!profile) {
+    return (
+      <div className="w-full mx-auto rounded-xl">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Unable to load profile.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto rounded-xl">
+      <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between mb-8">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <User className="w-4 h-4 text-[#1A1A1A]" fill="#1A1A1A" stroke="#1A1A1A" />
+            <h2 className="text-[18px] lg:text-[20px] text-[#1A1A1A]" style={TYPOGRAPHY.body}>
+              Personal Information
+            </h2>
+          </div>
+          <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+            Update your personal details and profile
+          </p>
+        </div>
+
+        <div className='flex justify-end'>
+          <OnboardingButton
+            label={isEditing ? 'Save Changes' : 'Edit Profile'}
+            icon={isEditing ? <Save size={18} /> : <Pencil size={18} />}
+            variant={isEditing ? 'solid' : 'plain'}
+            onClick={isEditing ? handleSaveChanges : () => setIsEditing(true)}
+            disabled={updateProfile.isPending}
+            className={`mt-0 mb-0 border-none ${isEditing ? 'max-w-[167px]' : 'bg-white max-w-[139px]'}`}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 mb-6">
+        <Avatar className="h-18 w-18 border border-[#EAEAEA]">
+          <AvatarImage src={formData.profilePictureUrl} alt="User Profile" className="object-cover" />
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+
+        {isEditing && (
+          <div className="flex flex-col gap-2 items-start">
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              accept="image/png, image/jpeg"
+              className="hidden"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center gap-2 px-4 py-2 border border-[#EAEAEA] rounded-lg bg-white text-[#1A1A1A] text-[14px] font-medium shadow-sm hover:bg-gray-50 transition-colors cursor-pointer"
+              style={TYPOGRAPHY.heading}
+            >
+              <Camera size={16} className="text-[#1A1A1A]" />
+              <span>Change Photo</span>
+            </button>
+            <span className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+              JPG, PNG up to 5MB
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
+        {(
+          [
+            { id: 'firstName', label: 'First Name', placeholder: 'Enter first name' },
+            { id: 'lastName', label: 'Last Name', placeholder: 'Enter last name' },
+            { id: 'userId', label: 'User ID', placeholder: 'Enter user id', alwaysDisabled: true },
+            { id: 'emailAddress', label: 'Email Address', placeholder: 'Enter email address', alwaysDisabled: true },
+            { id: 'phoneNumber', label: 'Phone Number', placeholder: 'Enter phone number' },
+          ] as Array<{ id: keyof ProfileFormData; label: string; placeholder: string; alwaysDisabled?: boolean }>
+        ).map(({ id, label, placeholder, alwaysDisabled }) => (
+          <OnboardingInput
+            key={id}
+            label={label}
+            placeholder={placeholder}
+            value={formData[id]}
+            disabled={alwaysDisabled || !isEditing}
+            onChange={(e) => handleInputChange(id, e.target.value)}
+            inputAreaStyle='bg-[#FFFFFF] text-[16px] text-[#858585]'
+          />
+        ))}
+      </div>
+
+      <div className="flex items-center gap-3 mt-8 mb-6 border-t border-[#F4F5F7]">
+        <MapPin className="w-5 h-5 text-[#1A1A1A]" />
+        <h3 className="text-[16px] lg:text-[20px] text-[#1A1A1A]" style={TYPOGRAPHY.body}>
+          Address Information
+        </h3>
+      </div>
+
+      <div className="w-full mb-2">
+        <OnboardingInput
+          label="Street Address"
+          placeholder="Enter street address"
+          value={formData.streetAddress}
+          disabled={!isEditing}
+          onChange={(e) => handleInputChange('streetAddress', e.target.value)}
+          inputAreaStyle='bg-[#FFFFFF] text-[16px] text-[#858585]'
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
+        {(
+          [
+            { id: 'city', label: 'City', placeholder: 'Enter city' },
+            { id: 'state', label: 'State', placeholder: 'Enter state' },
+          ] as const
+        ).map(({ id, label, placeholder }) => (
+          <OnboardingInput
+            key={id}
+            label={label}
+            placeholder={placeholder}
+            value={formData[id]}
+            disabled={!isEditing}
+            onChange={(e) => handleInputChange(id, e.target.value)}
+            inputAreaStyle='bg-[#FFFFFF] text-[16px] text-[#858585]'
+          />
+        ))}
+      </div>
+
+      {isEditing && (
+        <div className="flex flex-row gap-2 justify-end">
+          <OnboardingButton
+            label='Save Changes'
+            icon={<Save size={18} />}
+            variant="solid"
+            onClick={handleSaveChanges}
+            disabled={updateProfile.isPending}
+            className="max-w-[157px]"
+          />
+          <OnboardingButton
+            label='Cancel'
+            variant="plain"
+            onClick={handleCancel}
+            disabled={updateProfile.isPending}
+            className="max-w-[115px]"
+          />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/settings/organisms/Security.tsx
+++ b/src/components/settings/organisms/Security.tsx
@@ -2,9 +2,12 @@
 
 import React, { useState } from 'react';
 import { Smartphone, Laptop, X, LockKeyhole, Target, MonitorSmartphone } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from "@/constants/styles";
 import { OnboardingInput } from '@/components/onboarding/molecules/OnboardingInput';
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton';
+import { useChangePassword } from '@/hooks/use-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
 
 interface DeviceItem {
     id: string;
@@ -14,20 +17,21 @@ interface DeviceItem {
     location: string;
 }
 
+const COMING_SOON_FEATURES = true;
+
 export function Security() {
-    // Password state parameters
+    const changePassword = useChangePassword();
+
     const [passwords, setPasswords] = useState({
         current: '',
         new: '',
         confirm: ''
     });
 
-    // Security Feature Toggles
-    const [mfaActive, setMfaActive] = useState(true);
-    const [biometricActive, setBiometricActive] = useState(true);
+    const [mfaActive] = useState(false);
+    const [biometricActive] = useState(false);
 
-    // Trusted Devices List State Mock
-    const [devices, setDevices] = useState<DeviceItem[]>([
+    const [devices] = useState<DeviceItem[]>([
         { id: '1', type: 'mobile', name: 'iPhone 14 Pro', lastUsed: '12/15/2024', location: 'Lagos, Nigeria' },
         { id: '2', type: 'desktop', name: 'MacBook Pro', lastUsed: '12/14/2024', location: 'Lagos, Nigeria' }
     ]);
@@ -36,23 +40,41 @@ export function Security() {
         setPasswords(prev => ({ ...prev, [field]: value }));
     };
 
-    const handleRemoveDevice = (id: string) => {
-        setDevices(prev => prev.filter(device => device.id !== id));
-    };
-
     const handleUpdatePassword = (e: React.FormEvent) => {
         e.preventDefault();
-        if (passwords.new !== passwords.confirm) return;
-        // TODO: Integrate with password update API
-        setPasswords({ current: '', new: '', confirm: '' });
+        if (passwords.new !== passwords.confirm) {
+            return;
+        }
+
+        changePassword.mutate(
+            {
+                currentPassword: passwords.current,
+                newPassword: passwords.new,
+                confirmPassword: passwords.confirm,
+            },
+            {
+                onSuccess: () => {
+                    toast.success('Password updated');
+                    setPasswords({ current: '', new: '', confirm: '' });
+                },
+                onError: (error) => {
+                    showApiErrorToast(error, 'Unable to update password.');
+                },
+            }
+        );
     };
 
     const isPasswordMismatch = passwords.confirm.length > 0 && passwords.new !== passwords.confirm;
+    const isSubmitDisabled =
+        changePassword.isPending
+        || isPasswordMismatch
+        || !passwords.current
+        || !passwords.new
+        || !passwords.confirm;
 
     return (
         <div className="w-full">
 
-            {/* ==================== SECTION 1: PASSWORD SECURITY ==================== */}
             <div className="flex items-center gap-2 pb-1">
                 <LockKeyhole className="w-4 h-4 text-[#1A1A1A]" />
                 <h2 className="text-[16px] lg:text-[20px] text-[#1F1F1F] font-medium" style={TYPOGRAPHY.body}>
@@ -74,8 +96,6 @@ export function Security() {
                     inputAreaStyle="bg-[#FFFFFF] text-[16px] text-[#858585] pr-10"
                 />
 
-
-
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4 items-start">
 
                     <OnboardingInput
@@ -88,7 +108,6 @@ export function Security() {
                     />
 
                     <div>
-
                         <OnboardingInput
                             label="Confirm new password"
                             placeholder="Confirm new password"
@@ -97,7 +116,6 @@ export function Security() {
                             onChange={(e) => handlePasswordChange('confirm', e.target.value)}
                             inputAreaStyle="bg-[#FFFFFF] text-[16px] text-[#858585] pr-10"
                         />
-
 
                         {isPasswordMismatch && (
                             <span className="text-[#EF4444] text-[12px]" style={TYPOGRAPHY.body}>
@@ -110,15 +128,14 @@ export function Security() {
 
                 <div className="w-full flex justify-end">
                     <OnboardingButton
-                        label="Update Password"
+                        label={changePassword.isPending ? 'Updating...' : 'Update Password'}
                         type="submit"
-                        disabled={isPasswordMismatch || !passwords.current || !passwords.new}
+                        disabled={isSubmitDisabled}
                         className="bg-[#042E27] hover:bg-[#03241F] text-white max-w-[160px] rounded-lg text-[14px] font-medium"
                     />
                 </div>
             </form>
 
-            {/* ==================== SECTION 2: MULTI-FACTOR AUTHENTICATION ==================== */}
             <div className="flex items-center gap-2 mt-8 pb-1 pt-6 border-t border-[#F4F5F7]">
                 <LockKeyhole className="w-4 h-4 text-[#1A1A1A]" />
                 <h2 className="text-[16px] lg:text-[20px] text-[#1F1F1F]" style={TYPOGRAPHY.body}>
@@ -126,11 +143,10 @@ export function Security() {
                 </h2>
             </div>
             <p className="text-[14px] lg:text-[16px] text-[#858585] mb-6" style={TYPOGRAPHY.body}>
-                Add an extra layer of security to your account
+                Add an extra layer of security to your account. Coming soon.
             </p>
 
-            <div className="flex flex-col gap-4">
-                {/* MFA Status Component Row */}
+            <div className="flex flex-col gap-4 opacity-60">
                 <div className="flex items-center justify-between p-4 bg-white border border-[#EAEAEA] rounded-xl gap-4">
                     <div className="flex flex-col gap-0.5">
                         <h4 className="text-[14px] lg:text-[18px] font-medium text-[#1F1F1F]" style={TYPOGRAPHY.body}>MFA Status</h4>
@@ -152,15 +168,14 @@ export function Security() {
                             role="switch"
                             aria-checked={mfaActive}
                             aria-label="Toggle multi-factor authentication"
-                            onClick={() => setMfaActive(!mfaActive)}
-                            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#042E27] focus-visible:ring-offset-2 ${mfaActive ? 'bg-[#042E27]' : 'bg-[#E4E4E7]'}`}
+                            disabled={COMING_SOON_FEATURES}
+                            className={`relative inline-flex h-6 w-11 shrink-0 cursor-not-allowed rounded-full border-2 border-transparent transition-colors duration-200 ${mfaActive ? 'bg-[#042E27]' : 'bg-[#E4E4E7]'}`}
                         >
                             <span aria-hidden="true" className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 ${mfaActive ? 'translate-x-5' : 'translate-x-0'}`} />
                         </button>
                     </div>
                 </div>
 
-                {/* Biometric Configuration Row */}
                 <div className="flex items-center justify-between p-4 bg-white border border-[#EAEAEA] rounded-xl gap-4">
                     <div className="flex flex-col gap-0.5">
                         <h4 className="text-[14px] lg:text-[18px] font-medium text-[#1F1F1F]" style={TYPOGRAPHY.body}>Biometric Login</h4>
@@ -171,15 +186,14 @@ export function Security() {
                         role="switch"
                         aria-checked={biometricActive}
                         aria-label="Toggle biometric login"
-                        onClick={() => setBiometricActive(!biometricActive)}
-                        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#042E27] focus-visible:ring-offset-2 ${biometricActive ? 'bg-[#042E27]' : 'bg-[#E4E4E7]'}`}
+                        disabled={COMING_SOON_FEATURES}
+                        className={`relative inline-flex h-6 w-11 shrink-0 cursor-not-allowed rounded-full border-2 border-transparent transition-colors duration-200 ${biometricActive ? 'bg-[#042E27]' : 'bg-[#E4E4E7]'}`}
                     >
                         <span aria-hidden="true" className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 ${biometricActive ? 'translate-x-5' : 'translate-x-0'}`} />
                     </button>
                 </div>
             </div>
 
-            {/* ==================== SECTION 3: TRUSTED DEVICES ==================== */}
             <div className="flex items-center gap-2 mt-8 pb-1 pt-6">
                 <MonitorSmartphone className="w-5 h-5 text-[#1F1F1F]" />
                 <h2 className="text-[16px] lg:text-[20px] text-[#1F1F1F]" style={TYPOGRAPHY.body}>
@@ -187,10 +201,10 @@ export function Security() {
                 </h2>
             </div>
             <p className="text-[14px] lg:text-[16px] text-[#858585] mb-6" style={TYPOGRAPHY.body}>
-                Manage devices that can access your account
+                Manage devices that can access your account. Coming soon.
             </p>
 
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-3 opacity-60">
                 {devices.map((device) => (
                     <div
                         key={device.id}
@@ -211,19 +225,14 @@ export function Security() {
                         </div>
                         <button
                             type="button"
-                            onClick={() => handleRemoveDevice(device.id)}
-                            className="p-1.5 text-gray-400 hover:text-red-500 rounded-md transition-colors cursor-pointer"
+                            disabled={COMING_SOON_FEATURES}
+                            className="p-1.5 text-gray-400 rounded-md cursor-not-allowed"
                             title="Revoke device access authorization credentials"
                         >
                             <X size={18} />
                         </button>
                     </div>
                 ))}
-                {devices.length === 0 && (
-                    <div className="text-center py-6 text-gray-400 text-[14px] bg-gray-50 rounded-xl border border-dashed border-gray-200">
-                        No custom active devices linked to authorization cache profile.
-                    </div>
-                )}
             </div>
 
         </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,8 @@ export const CACHE_KEY_DASHBOARD = ["dashboard"] as const;
 export const CACHE_KEY_WALLET_TRANSACTIONS = ["wallet-transactions"] as const;
 export const CACHE_KEY_PAYMENT_METHODS = ["payment-methods"] as const;
 export const CACHE_KEY_WATCHLIST = ["watchlist"] as const;
+export const CACHE_KEY_INVESTOR_PROFILE = ["investor-profile"] as const;
+export const CACHE_KEY_INVESTOR_ACCOUNT = ["investor-account"] as const;
 
 export const ACCESS_TOKEN_KEY = "access_token";
 export const REFRESH_TOKEN_KEY = "refresh_token";

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CACHE_KEY_INVESTOR_ACCOUNT, CACHE_KEY_INVESTOR_PROFILE } from "@/constants";
+import settingsService from "@/services/settingsService";
+import authService from "@/services/authService";
+import type { ChangePasswordRequest } from "@/types/auth";
+import type { UpdateInvestorProfileRequest } from "@/types/settings";
+
+export function useInvestorProfile() {
+  return useQuery({
+    queryKey: CACHE_KEY_INVESTOR_PROFILE,
+    queryFn: () => settingsService.getProfile(),
+  });
+}
+
+export function useInvestorAccount() {
+  return useQuery({
+    queryKey: CACHE_KEY_INVESTOR_ACCOUNT,
+    queryFn: () => settingsService.getAccount(),
+  });
+}
+
+export function useUpdateInvestorProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: UpdateInvestorProfileRequest) =>
+      settingsService.updateProfile(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CACHE_KEY_INVESTOR_PROFILE });
+    },
+  });
+}
+
+export function useChangePassword() {
+  return useMutation({
+    mutationFn: (payload: ChangePasswordRequest) => authService.changePassword(payload),
+  });
+}

--- a/src/lib/settings-mappers.ts
+++ b/src/lib/settings-mappers.ts
@@ -1,0 +1,107 @@
+import type { InvestorProfile, InvestorAccount } from "@/types/settings";
+import type {
+  AccountDataProfile,
+  ComplianceCheckItem,
+  InvestmentLimitsMetrics,
+} from "@/components/settings/organisms/Account";
+
+export interface ProfileFormData {
+  firstName: string;
+  lastName: string;
+  userId: string;
+  emailAddress: string;
+  phoneNumber: string;
+  streetAddress: string;
+  city: string;
+  state: string;
+  profilePictureUrl: string;
+}
+
+export function mapProfileToFormData(profile: InvestorProfile): ProfileFormData {
+  return {
+    firstName: profile.firstName,
+    lastName: profile.lastName,
+    userId: String(profile.id),
+    emailAddress: profile.email,
+    phoneNumber: profile.phoneNumber,
+    streetAddress: profile.residentialAddress,
+    city: profile.countryOfResidence,
+    state: profile.stateOfResidence,
+    profilePictureUrl: "/dashboard/User-Avatar.png",
+  };
+}
+
+export function mapFormDataToUpdateRequest(
+  formData: ProfileFormData,
+  profile: InvestorProfile
+) {
+  return {
+    firstName: formData.firstName,
+    lastName: formData.lastName,
+    preferredName: profile.preferredName ?? null,
+    phoneNumber: formData.phoneNumber,
+    residentialAddress: formData.streetAddress,
+    stateOfResidence: formData.state,
+    countryOfResidence: formData.city,
+  };
+}
+
+function formatAccountDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString("en-US", {
+    month: "numeric",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function mapAccountToProfile(account: InvestorAccount): AccountDataProfile {
+  return {
+    accountType: account.accountType,
+    accountStatus: account.accountStatus as AccountDataProfile["accountStatus"],
+    kycStatus: account.kycStatus as AccountDataProfile["kycStatus"],
+    kycCompletedDate: account.kycCompletedDate
+      ? formatAccountDate(account.kycCompletedDate)
+      : "",
+    investorClassification: account.investorClassification,
+    verificationStatus: account.verificationStatus as AccountDataProfile["verificationStatus"],
+    memberSince: formatAccountDate(account.memberSince),
+    riskRating: account.riskRating as AccountDataProfile["riskRating"],
+  };
+}
+
+const DEFAULT_LIMITS: InvestmentLimitsMetrics = {
+  annualLimit: 5_000_000,
+  usedPercentage: 0,
+  perProjectLimit: 1_000_000,
+  lifetimeLimit: 20_000_000,
+};
+
+export function mapAccountLimits(
+  account: InvestorAccount
+): InvestmentLimitsMetrics {
+  if (!account.investmentLimits) {
+    return DEFAULT_LIMITS;
+  }
+
+  return {
+    annualLimit: account.investmentLimits.annualLimit,
+    usedPercentage: account.investmentLimits.usedPercentage,
+    perProjectLimit: account.investmentLimits.perProjectLimit,
+    lifetimeLimit: account.investmentLimits.lifetimeLimit,
+  };
+}
+
+export function mapAccountCompliance(
+  account: InvestorAccount
+): ComplianceCheckItem[] {
+  return account.complianceChecks.map((item) => ({
+    id: item.id,
+    label: item.label,
+    status: item.status as ComplianceCheckItem["status"],
+  }));
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -12,6 +12,7 @@ import type {
   ResendVerificationRequest,
   SignupRequest,
   VerifyEmailRequest,
+  ChangePasswordRequest,
 } from "@/types/auth";
 import type { ApiResponse } from "@/types/api";
 
@@ -24,6 +25,7 @@ export type {
   ResendVerificationRequest,
   SignupRequest,
   VerifyEmailRequest,
+  ChangePasswordRequest,
 };
 
 const loginApi = new ApiClient<LoginRequest, LoginResponse>("/api/auth/login");
@@ -81,6 +83,17 @@ const authService = {
     }
   },
   deleteAccount: (userId: number) => usersApi.delete(String(userId)),
+  changePassword: async (payload: ChangePasswordRequest): Promise<void> => {
+    try {
+      const response = await request.post<ApiResponse<void>>(
+        "/api/auth/change-password",
+        payload
+      );
+      unwrap(response.data);
+    } catch (error) {
+      throw toApiError(error);
+    }
+  },
   logout,
 };
 

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,0 +1,42 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type { InvestorProfile, InvestorAccount, UpdateInvestorProfileRequest } from "@/types/settings";
+import { toApiError } from "@/lib/api-error";
+
+const PROFILE_BASE = "/api/investors/me/profile";
+const ACCOUNT_BASE = "/api/investors/me/account";
+
+async function getProfile(): Promise<InvestorProfile> {
+  try {
+    const res = await request.get<ApiResponse<InvestorProfile>>(PROFILE_BASE);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function updateProfile(payload: UpdateInvestorProfileRequest): Promise<InvestorProfile> {
+  try {
+    const res = await request.put<ApiResponse<InvestorProfile>>(PROFILE_BASE, payload);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function getAccount(): Promise<InvestorAccount> {
+  try {
+    const res = await request.get<ApiResponse<InvestorAccount>>(ACCOUNT_BASE);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const settingsService = {
+  getProfile,
+  updateProfile,
+  getAccount,
+};
+
+export default settingsService;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -70,3 +70,9 @@ export interface DeleteUnverifiedRequest {
   email: string;
   otp: string;
 }
+
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,51 @@
+export interface InvestorProfile {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  preferredName?: string | null;
+  phoneNumber: string;
+  residentialAddress: string;
+  stateOfResidence: string;
+  countryOfResidence: string;
+  dateOfBirth: string;
+  nationality: string;
+  userType: string;
+  isEmailVerified: boolean;
+}
+
+export interface UpdateInvestorProfileRequest {
+  firstName: string;
+  lastName: string;
+  preferredName?: string | null;
+  phoneNumber: string;
+  residentialAddress: string;
+  stateOfResidence: string;
+  countryOfResidence: string;
+}
+
+export interface InvestorInvestmentLimits {
+  annualLimit: number;
+  usedPercentage: number;
+  perProjectLimit: number;
+  lifetimeLimit: number;
+}
+
+export interface InvestorComplianceCheck {
+  id: string;
+  label: string;
+  status: string;
+}
+
+export interface InvestorAccount {
+  accountType: string;
+  accountStatus: string;
+  kycStatus: string;
+  kycCompletedDate: string | null;
+  investorClassification: string;
+  verificationStatus: string;
+  memberSince: string;
+  riskRating: string;
+  investmentLimits: InvestorInvestmentLimits | null;
+  complianceChecks: InvestorComplianceCheck[];
+}


### PR DESCRIPTION
## Summary
- Integrate Profile tab with `GET/PUT /api/investors/me/profile` (including editable phone number)
- Integrate Account tab and settings header badge with `GET /api/investors/me/account`
- Integrate Security tab change-password flow with `POST /api/auth/change-password`
- Wire Preferences delete-account and fix settings deep links in nav/command search

## Test plan
- [x] `pnpm type-check` passes
- [x] Local smoke test at `/settings` (profile load/save, account tab, security form, payment tab)
- [x] Staging smoke test after API deploy

**Depends on:** antital-api settings endpoints PR


Made with [Cursor](https://cursor.com)