### PR TITLE
Fix guest CTAs, auth userType sync, and dashboard QA feedback

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,97 +1,61 @@
-# Investment Explore UI Integration
+# Feedback from testing — bugfix plan
 
 ## Goal
 
-Replace static `investments.json` and hardcoded detail sections with the domain-first `/api/investments` backend.
+Fix guest, KYC, dashboard, and marketplace issues reported from QA testing so public browsing and core authenticated flows work as expected.
 
 ## Scope
 
-- Types, service, React Query hooks for list + detail bundle.
-- Landing/explore cards, new launches carousel.
-- Detail page composes domain resources (highlights, content-blocks, team, financials, etc.).
+- Guest homepage / landing CTAs and campaign detail actions.
+- Guest About Us CTA.
+- KYC validation for first two stages (non-skip path).
+- Dashboard/portfolio chart toggle, kebab menu, and graph/data alignment.
+- Marketplace sidebar label rename.
+- Login: sync `userType` from API into persisted store (correct investor vs fundraiser dashboard).
+- Preserve prior fix: explore detail stays public for guests (no forced login on load).
 
 ## Out Of Scope
 
-- Invest / watchlist / ask-question authenticated actions.
-- Admin listing CRUD.
-
-## API contracts and endpoints available
-
-See `antital-api/PLAN.md`. UI consumes:
-
-- `GET /api/investments`
-- `GET /api/investments/{idOrSlug}` + sub-resources (parallel fetch in one hook)
+- Building a real secondary-market trading product (MVP: Coming Soon only).
+- Building a full founder “apply to list” product (MVP: fix dead link only).
+- Backend watchlist/invest API contract changes.
+- Unrelated footer 404s (`/investments`, `/fixed-savings`, etc.) unless they appear in this feedback list.
 
 ## Checkpoints
 
 | # | Checkpoint | Status |
-|---|------------|--------|
-| 1 | Types, service, mappers, hooks | completed |
-| 2 | List integration (landing, explore, new launches) | completed |
-| 3 | Detail page + section props from API | completed |
-| 4 | Browser verification (Playwright) | completed |
+|---|---|---|
+| 0 | Explore detail public for guests (watchlist status + 401 interceptor) | completed |
+| 1 | Guest homepage CTAs + secondary market Coming Soon | completed |
+| 2 | Guest campaign detail actions (share, watchlist, Start trading ×N) | completed |
+| 3 | Guest About Us — Explore investment | completed |
+| 4 | KYC — require first 2 stages before proceed (non-skip) | completed |
+| 5 | Dashboard — portfolio toggle, kebab, graph vs holdings | completed |
+| 6 | Sidebar — rename Trade & Market → Marketplace | completed |
+| 7 | Login — sync userType from API to localStorage | completed |
+| 8 | Playwright / browser verification of fixed flows | completed |
 
 ## Permission rule
 
-Implement checkpoints sequentially; update status when complete.
+All checkpoints implemented in this branch per user approval.
 
 ---
 
-## Checkpoint 1 — Types, service, mappers, hooks
+## Issue tracker (QA feedback)
 
-- [x] Status: completed
-
-**Files:** `src/types/investment.ts`, `src/services/investmentService.ts`, `src/lib/investment-mappers.ts`, `src/hooks/use-investments.ts`, `src/hooks/use-investment-detail.ts`, `src/constants.ts`
-
-**Done criteria:** Service calls all public investment routes; hooks expose list + detail bundle.
-
----
-
-## Checkpoint 2 — List integration
-
-- [x] Status: completed
-
-**UI entry:** Landing `InvestmentOpportunities`, explore page, `NewLaunches`.
-
-**Files:** `investment-opportunities.tsx`, `new-launches.tsx`
-
-**Done criteria:** Cards render from API with loading/error states; links use slug.
-
-**Verified:** Landing at `http://localhost:3000/` shows AgriTech Innovations, AquaPure Innovations, EcoBuild Materials from API.
-
----
-
-## Checkpoint 3 — Detail page
-
-- [x] Status: completed
-
-**UI entry:** `/explore/[id]`
-
-**Files:** `explore/[id]/page.tsx`, `investment-detail-page-client.tsx`, `investment-detail-page-content.tsx`, investment section components
-
-**Done criteria:** Page fetches shell + sub-resources; no hardcoded NEXUS AI copy; UI composes domain data.
-
-**Verified:** `/explore/greentech-solutions` renders GreenTech Solutions with API highlights, team, financials, deal terms, and funding panel.
-
----
-
-## Checkpoint 4 — Browser verification
-
-- [x] Status: completed
-
-**Done criteria:** Landing shows API cards; detail page for `greentech-solutions` shows GreenTech data from API.
-
-**Test notes (Playwright, 2026-05-31):**
-
-- Landing cards load after React Query fetch (no static JSON).
-- Detail overview: problem statement, ₦675M ARR highlight, proprietary edge, market traction, TL;DR.
-- Detail tab: Dr. Eleanor Vance / Alex Chen team, financial metrics table, use of proceeds, risks, documents.
-- Investment panel: ₦7,381,254 raised, 341 investors, target rating 4.5.
-- Minor: seed media thumbnails (`/investments/thumb*.jpg`) 404 in Next image optimizer — assets not in `public/` yet.
-
-## Readiness checklist
-
-- [x] API running with investment routes (`https://localhost:7008`)
-- [x] UI `NEXT_PUBLIC_API_URL` points at API
-- [x] GreenTech full detail seeded on backend
-- [ ] Optional follow-up: add thumbnail assets to `public/investments/` or update seed URLs
+| ID | Area | Issue | Status |
+|---|---|---|---|
+| G1 | Guest homepage | Share button on campaigns unresponsive | fixed |
+| G2 | Guest homepage | Add to watchlist on guest campaign unresponsive | fixed |
+| G3 | Guest homepage | Start trading buttons on guest campaign | fixed (via checkout hook) |
+| G4 | Guest homepage | Hero Invest now → 404 | fixed → `/create-account` |
+| G5 | Guest homepage | Secondary market Start trading → 404 | fixed → `/secondary-market` + Coming Soon |
+| G6 | Guest homepage | Apply to list → 404 | fixed → `/create-account` |
+| A1 | Guest About Us | Explore investment unresponsive | fixed → `/explore` |
+| K1 | Sign up KYC | Proceed without first 2 KYC stages | fixed validation + review labels |
+| D1 | Dashboard | Portfolio stat / distribution toggle | fixed controlled select |
+| D2 | Dashboard | Three-dot does nothing | fixed (removed) |
+| D3 | Dashboard | Graph vs portfolio mismatch | fixed currency + holdings dist |
+| M1 | Trade & market | Rename sidebar to Marketplace | fixed |
+| U1 | Login / dashboard | Wrong userType (fundraiser default) | fixed API sync |
+| P0 | Explore detail | Guest forced to login | fixed |

--- a/src/app/(dashboard)/dashboard/Dashboard.tsx
+++ b/src/app/(dashboard)/dashboard/Dashboard.tsx
@@ -71,6 +71,7 @@ export function Dashboard() {
                     <PortfolioStatChart
                         portfolioPerformance={data?.portfolioPerformance}
                         activeDeals={data?.activeDeals}
+                        holdings={data?.holdings}
                         isLoading={isLoading}
                     />
                     : <div className="grid grid-cols-1 xl:grid-cols-10 mb-12 gap-5">

--- a/src/app/(dashboard)/dashboard/components/chart-area-interactive.tsx
+++ b/src/app/(dashboard)/dashboard/components/chart-area-interactive.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
-import { MoreVertical, Plus } from "lucide-react"
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
 import Image from "next/image"
 
 import {
@@ -22,16 +21,23 @@ import { TYPOGRAPHY } from "@/constants/styles"
 import { useMemo, useRef, useState } from "react"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
-import type { DashboardActiveDeal, DashboardPerformancePoint } from "@/types/dashboard-api"
+import type { DashboardActiveDeal, DashboardHolding, DashboardPerformancePoint } from "@/types/dashboard-api"
+
+type DashboardChartView = "portfolio-stat" | "investment-dist"
+
+const CHART_VIEW_LABELS: Record<DashboardChartView, string> = {
+  "portfolio-stat": "Portfolio Stat",
+  "investment-dist": "Investment dist",
+}
 
 const portfolioData = [
-  { month: "Jan", year: "2019", units: 10 },
-  { month: "Feb", year: "2020", units: 55 },
-  { month: "Mar", year: "2021", units: 45 },
-  { month: "Apr", year: "2022", units: 35 },
-  { month: "May", year: "2023", units: 50 },
-  { month: "Jun", year: "2024", units: 48 },
-  { month: "Jul", year: "2025", units: 65 },
+  { month: "Jan", year: "2019", value: 10 },
+  { month: "Feb", year: "2020", value: 55 },
+  { month: "Mar", year: "2021", value: 45 },
+  { month: "Apr", year: "2022", value: 35 },
+  { month: "May", year: "2023", value: 50 },
+  { month: "Jun", year: "2024", value: 48 },
+  { month: "Jul", year: "2025", value: 65 },
 ]
 
 const formatCurrency = (amount: number) =>
@@ -57,6 +63,7 @@ const activeDealTextStyle = {
 interface PortfolioStatChartProps {
   portfolioPerformance?: DashboardPerformancePoint[]
   activeDeals?: DashboardActiveDeal[]
+  holdings?: DashboardHolding[]
   isLoading?: boolean
   state?: boolean
 }
@@ -64,6 +71,7 @@ interface PortfolioStatChartProps {
 export function PortfolioStatChart({
   portfolioPerformance,
   activeDeals,
+  holdings,
   isLoading = false,
   state = false,
 }: PortfolioStatChartProps) {
@@ -74,15 +82,16 @@ export function PortfolioStatChart({
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(false);
+  const [chartView, setChartView] = useState<DashboardChartView>("portfolio-stat");
 
-  const chartData = useMemo(() => {
+  const performanceChartData = useMemo(() => {
     if ((isDashboardPage || isPortfolioPage) && portfolioPerformance && portfolioPerformance.length > 0) {
       return portfolioPerformance.map((point) => {
         const [monthLabel, yearLabel] = point.periodLabel.split(" ")
         return {
           month: monthLabel,
           year: yearLabel ?? "",
-          units: point.value,
+          value: point.value,
         }
       })
     }
@@ -90,9 +99,29 @@ export function PortfolioStatChart({
     return portfolioData
   }, [isDashboardPage, isPortfolioPage, portfolioPerformance])
 
-  const portfolioHasData = useMemo(() =>
-    chartData.some(d => d.units !== undefined && d.units > 0),
-    [chartData]);
+  const distributionChartData = useMemo(() => {
+    if (!holdings?.length) return []
+
+    const bySector = new Map<string, number>()
+    for (const holding of holdings) {
+      const sector = holding.sector?.trim() || "Other"
+      bySector.set(sector, (bySector.get(sector) ?? 0) + holding.invested)
+    }
+
+    return Array.from(bySector.entries()).map(([sector, invested]) => ({
+      sector,
+      invested,
+    }))
+  }, [holdings])
+
+  const chartData = chartView === "investment-dist" ? distributionChartData : performanceChartData
+
+  const portfolioHasData = useMemo(() => {
+    if (chartView === "investment-dist") {
+      return distributionChartData.some((item) => item.invested > 0)
+    }
+    return performanceChartData.some((d) => d.value !== undefined && d.value > 0)
+  }, [chartView, distributionChartData, performanceChartData]);
 
   const deals = useMemo(() => {
     if (isDashboardPage) {
@@ -140,7 +169,7 @@ export function PortfolioStatChart({
               Portfolio Stats
             </h3>
           ) : (
-            <Select>
+            <Select value={chartView} onValueChange={(value) => setChartView(value as DashboardChartView)}>
               <SelectTrigger
                 className="h-auto py-6 px-4 border-[#A8A8A8] rounded-md bg-white cursor-pointer focus:ring-0 font-bold text-black"
                 style={{
@@ -149,21 +178,50 @@ export function PortfolioStatChart({
                   fontWeight: 500
                 }}
               >
-                <SelectValue placeholder="Portfolio Stat" />
+                <SelectValue>{CHART_VIEW_LABELS[chartView]}</SelectValue>
               </SelectTrigger>
 
               <SelectContent>
                 <SelectGroup>
+                  <SelectItem value="portfolio-stat">Portfolio Stat</SelectItem>
                   <SelectItem value="investment-dist">Investment dist</SelectItem>
                 </SelectGroup>
               </SelectContent>
             </Select>
           )}
-          <MoreVertical className="h-5 w-5 text-[#6A7682] cursor-pointer" />
         </CardHeader>
 
         <CardContent className={hasActivePortfolio ? "pt-4" : "flex flex-col items-center justify-center min-h-[350px]"}>
           <ChartContainer config={{}} className={isPortfolioPage ? "h-[350px] w-full" : "h-[300px] w-full"}>
+            {chartView === "investment-dist" && isDashboardPage ? (
+              <BarChart data={chartData} margin={{ left: -10, right: 10 }}>
+                <CartesianGrid stroke="#F0F0F0" />
+                <XAxis
+                  dataKey="sector"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: '#A2A3A1', fontSize: 12 }}
+                  dy={10}
+                />
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: '#A2A3A1', fontSize: 12 }}
+                  tickFormatter={(value: number) => formatCurrency(value)}
+                  domain={[0, 'auto']}
+                />
+                <ChartTooltip content={({ active, payload }) => (
+                  active && payload?.length ? (
+                    <div className="bg-[#55B32B] px-3 py-1 rounded text-white text-xs font-bold shadow-lg">
+                      {formatCurrency(Number(payload[0].value))}
+                    </div>
+                  ) : null
+                )} />
+                {hasActivePortfolio && (
+                  <Bar dataKey="invested" fill="#55B32B" radius={[4, 4, 0, 0]} />
+                )}
+              </BarChart>
+            ) : (
             <AreaChart data={chartData} margin={{ left: -20, right: 10 }}>
               <defs>
                 <linearGradient id="colorUnits" x1="0" y1="0" x2="0" y2="1">
@@ -180,23 +238,25 @@ export function PortfolioStatChart({
               <YAxis
                 axisLine={false} tickLine={false}
                 tick={{ fill: '#A2A3A1', fontSize: 12 }}
+                tickFormatter={(value: number) => formatCurrency(value)}
                 domain={[0, 'auto']}
               />
               <ChartTooltip content={({ active, payload }) => (
                 active && payload?.length ? (
                   <div className="bg-[#55B32B] px-3 py-1 rounded text-white text-xs font-bold shadow-lg">
-                    {payload[0].value} units
+                    {formatCurrency(Number(payload[0].value))}
                   </div>
                 ) : null
               )} />
               {hasActivePortfolio && (
                 <Area
-                  type="monotone" dataKey="units" stroke="#55B32B" strokeWidth={3}
+                  type="monotone" dataKey="value" stroke="#55B32B" strokeWidth={3}
                   fillOpacity={1} fill="url(#colorUnits)"
                   activeDot={{ r: 6, fill: "#fff", stroke: "#55B32B", strokeWidth: 2 }}
                 />
               )}
             </AreaChart>
+            )}
           </ChartContainer>
         </CardContent>
       </Card>
@@ -205,7 +265,6 @@ export function PortfolioStatChart({
         <Card className="bg-white">
           <CardHeader className="flex justify-between items-center">
             <p className="text-[16px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>Active Deals</p>
-            <button className="bg-[#042E27] p-1 rounded-sm"><Plus className="h-4 w-4 text-white" /></button>
           </CardHeader>
 
           <CardContent className={hasActiveDeals ? "p-0 relative overflow-hidden" : "flex flex-col items-center justify-center min-h-[350px]"}>

--- a/src/app/(dashboard)/dashboard/components/data-table.tsx
+++ b/src/app/(dashboard)/dashboard/components/data-table.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { Filter, MoreVertical, Search } from "lucide-react"
+import { Filter, Search } from "lucide-react"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { TYPOGRAPHY } from "@/constants/styles"
@@ -160,7 +160,6 @@ export function DataTable({ state = false, holdings, isLoading = false, userType
                 <SelectItem value="amount-raised">Amount Raised</SelectItem>
               </SelectContent>
             </Select>
-            <MoreVertical className="h-5 w-5 text-[#323232] cursor-pointer" />
           </div>
         </CardHeader>
 

--- a/src/app/(dashboard)/dashboard/components/section-cards.tsx
+++ b/src/app/(dashboard)/dashboard/components/section-cards.tsx
@@ -128,7 +128,7 @@ function SummaryCard({
         </div>
       </CardContent>
       {footerText && (
-        <CardFooter className="px-5 py-3 flex justify-between items-center cursor-pointer hover:opacity-80 transition-opacity bg-[#E6EAE9] border-t border-[#EAEAEA]">
+        <CardFooter className="px-5 py-3 flex justify-between items-center bg-[#E6EAE9] border-t border-[#EAEAEA]">
           <span className="text-[14px] text-[#042E27]" style={TYPOGRAPHY.heading}>
             {footerText}
           </span>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import { useSidebarConfig } from "@/hooks/use-sidebar-config";
 import { DashboardHeader } from "@/components/dashboard/organisms/DashboardHeader";
 import { InfoBanner } from "@/components/dashboard/organisms/InfoBanner";
 import { useRouter } from "next/navigation";
+import { SyncUserProfile } from "@/components/auth/sync-user-profile";
 import { useUserStore } from "@/store/userStore";
 
 export default function DashboardLayout({
@@ -36,7 +37,8 @@ export default function DashboardLayout({
   const router = useRouter();
 
   return (
-
+    <>
+      <SyncUserProfile />
     <SidebarProvider
       style={{
         "--sidebar-width": isMobile ? "50vw" : "16rem",
@@ -76,5 +78,6 @@ export default function DashboardLayout({
 
       <FloatingChatButton />
     </SidebarProvider>
+    </>
   );
 }

--- a/src/app/(dashboard)/portfolio/components/Portfolio.tsx
+++ b/src/app/(dashboard)/portfolio/components/Portfolio.tsx
@@ -49,6 +49,7 @@ export function Portfolio() {
                 <SectionCards summary={data?.summary} isLoading={isLoading} />
                 <PortfolioStatChart
                     portfolioPerformance={data?.portfolioPerformance}
+                    holdings={data?.holdings}
                     isLoading={isLoading}
                 />
             </div>

--- a/src/app/(marketing)/about/about-page-content.tsx
+++ b/src/app/(marketing)/about/about-page-content.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { ValueCard } from '@/components/about/molecules/value-card'
 import { FeatureCard } from '@/components/about/molecules/feature-card'
 import { Briefcase, ShieldCheck, TrendingUp, ArrowLeftRight } from 'lucide-react'
@@ -345,7 +346,8 @@ export function AboutPageContent() {
                 </div>
 
                 {/* CTA Button */}
-                <button
+                <Link
+                  href="/explore"
                   className="flex items-center justify-center gap-2 px-4 py-2 w-[204px] h-[48px] bg-[#B9C65B] hover:bg-[#B9C65B]/90 rounded-lg transition-colors"
                 >
                   <span
@@ -374,7 +376,7 @@ export function AboutPageContent() {
                       strokeLinejoin="round"
                     />
                   </svg>
-                </button>
+                </Link>
               </div>
             </div>
           </div>

--- a/src/app/(marketing)/secondary-market/secondary-market-landing-page-content.tsx
+++ b/src/app/(marketing)/secondary-market/secondary-market-landing-page-content.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ComingSoonBanner } from '@/components/secondary-market/molecules/coming-soon-banner'
 import { SecondaryMarketHero } from '@/components/secondary-market/organisms/SecondaryMarketHero'
 import { WhatIsTheAntitalSecondaryMarket } from '@/components/secondary-market/organisms/WhatIsTheAntitalSecondaryMarket'
 import { HowToInvest } from '@/components/secondary-market/organisms/HowToInvest'
@@ -11,6 +12,7 @@ import { FAQ } from '@/components/landing/organisms/faq'
 export default function SecondaryMarketLandingPageContent() {
     return (
         <div className="min-h-screen bg-background">
+            <ComingSoonBanner />
             <SecondaryMarketHero />
             <WhatIsTheAntitalSecondaryMarket />
             <HowToInvest />

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -32,7 +32,7 @@ const investorNavGroups = [
     items: [
       { title: "Dashboard", url: "/dashboard", icon: LayoutDashboard },
       { title: "Portfolio", url: "/portfolio", icon: BriefcaseBusiness },
-      { title: "Trade & Market", url: "/marketplace", icon: ChartLine },
+      { title: "Marketplace", url: "/marketplace", icon: ChartLine },
       { title: "Fixed Savings", url: "/fixed-savings", icon: PiggyBank },
       { title: "Balance & Funding", url: "/balance-funding", icon: Wallet },
       { title: "Watchlist", url: "/watchlist", icon: Eye },

--- a/src/components/auth/sync-user-profile.tsx
+++ b/src/components/auth/sync-user-profile.tsx
@@ -8,17 +8,17 @@ import { useUserStore } from "@/store/userStore";
 /** Keeps persisted userType aligned with the API profile on session restore. */
 export function SyncUserProfile() {
   const { data: user } = useCurrentUser();
-  const updateProfile = useUserStore((state) => state.updateProfile);
 
   useEffect(() => {
     if (!user) return;
 
+    const { updateProfile, setUserId } = useUserStore.getState();
     updateProfile({
       emailAddress: user.email,
       userType: mapApiUserTypeToStoreUserType(user.userType),
     });
-    useUserStore.getState().setUserId(String(user.id));
-  }, [user, updateProfile]);
+    setUserId(String(user.id));
+  }, [user]);
 
   return null;
 }

--- a/src/components/auth/sync-user-profile.tsx
+++ b/src/components/auth/sync-user-profile.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useCurrentUser } from "@/hooks/use-current-user";
+import { mapApiUserTypeToStoreUserType } from "@/lib/user-type";
+import { useUserStore } from "@/store/userStore";
+
+/** Keeps persisted userType aligned with the API profile on session restore. */
+export function SyncUserProfile() {
+  const { data: user } = useCurrentUser();
+  const updateProfile = useUserStore((state) => state.updateProfile);
+
+  useEffect(() => {
+    if (!user) return;
+
+    updateProfile({
+      emailAddress: user.email,
+      userType: mapApiUserTypeToStoreUserType(user.userType),
+    });
+    useUserStore.getState().setUserId(String(user.id));
+  }, [user, updateProfile]);
+
+  return null;
+}

--- a/src/components/investment/molecules/media-thumbnails.tsx
+++ b/src/components/investment/molecules/media-thumbnails.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import { ThumbsUp, Share2 } from 'lucide-react'
+import { shareCurrentPage } from '@/lib/share-page'
 
 interface MediaThumbnailsProps {
   thumbnails?: string[]
@@ -92,6 +93,10 @@ export function MediaThumbnails({
 
         {/* Share Button */}
         <button
+          type="button"
+          onClick={() => {
+            void shareCurrentPage()
+          }}
           className="cursor-pointer border-none bg-transparent p-0"
           style={{
             width: '24px',

--- a/src/components/investment/organisms/investment-panel.tsx
+++ b/src/components/investment/organisms/investment-panel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useRouter } from 'next/navigation'
 import { Gauge, Bookmark, BookmarkCheck } from 'lucide-react'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
@@ -14,6 +15,7 @@ import {
 } from '@/hooks/use-watchlist'
 import { isApiErrorStatus } from '@/lib/api-error'
 import { showApiErrorToast } from '@/lib/error-feedback'
+import { tokenStorage } from '@/lib/token-storage'
 
 interface InvestmentPanelProps {
   offeringId: number
@@ -22,6 +24,7 @@ interface InvestmentPanelProps {
 }
 
 export function InvestmentPanel({ offeringId, slug, funding }: InvestmentPanelProps) {
+  const router = useRouter()
   const startCheckout = useStartInvestmentCheckout()
   const { data: status, isLoading: isStatusLoading } = useWatchlistStatus(offeringId)
   const addToWatchlist = useAddToWatchlist()
@@ -33,6 +36,11 @@ export function InvestmentPanel({ offeringId, slug, funding }: InvestmentPanelPr
   }
 
   const handleAddToWatchlist = () => {
+    if (!tokenStorage.getAccessToken()) {
+      router.push('/sign-in')
+      return
+    }
+
     if (isWatchlisted || addToWatchlist.isPending) {
       return
     }

--- a/src/components/landing/organisms/hero.tsx
+++ b/src/components/landing/organisms/hero.tsx
@@ -58,7 +58,7 @@ export function Hero() {
               }}
               asChild
             >
-              <Link href="/auth/sign-up" className="flex items-center justify-between w-full">
+              <Link href="/create-account" className="flex items-center justify-between w-full">
                 <span className="mx-auto">Invest Now</span>
                 <ArrowRight className="h-6 w-6" />
               </Link>

--- a/src/components/landing/organisms/raise-capital.tsx
+++ b/src/components/landing/organisms/raise-capital.tsx
@@ -64,7 +64,7 @@ export function RaiseCapital() {
               }}
               asChild
             >
-              <Link href="/apply" className="flex items-center justify-center gap-2">
+              <Link href="/create-account" className="flex items-center justify-center gap-2">
                 <span>Apply to List Your Startup</span>
                 <ArrowRight className="h-6 w-6" />
               </Link>

--- a/src/components/landing/organisms/secondary-market.tsx
+++ b/src/components/landing/organisms/secondary-market.tsx
@@ -36,7 +36,7 @@ export function SecondaryMarket() {
 
             {/* Buttons */}
             <ButtonGroup
-              primaryHref="/secondary-market/trade"
+              primaryHref="/secondary-market"
               primaryText="Start trading"
               secondaryHref="/secondary-market"
               secondaryText="Learn more"

--- a/src/components/onboarding/organisms/corporate/CorporateInvestorReview.tsx
+++ b/src/components/onboarding/organisms/corporate/CorporateInvestorReview.tsx
@@ -6,6 +6,16 @@ import { useOnboardingStore } from "@/store/onboardingStore"
 import { ReviewCard } from "@/components/onboarding/molecules/ReviewCard"
 import { InvestorUserType } from "@/constants/steps"
 
+function formatTextField(value: string | undefined | null): string {
+    return value?.trim() ? value : "Pending";
+}
+
+function formatUploadField(value: File | string | null | undefined): string {
+    if (value instanceof File && value.size > 0) return "Uploaded";
+    if (typeof value === "string" && value.trim()) return "Uploaded";
+    return "Pending";
+}
+
 export function CorporateInvestorReview() {
     const router = useRouter();
     const params = useParams();
@@ -100,11 +110,11 @@ export function CorporateInvestorReview() {
                 isStatusType
                 onEditClick={() => handleEdit("kyc")}
                 items={[
-                    { label: "ID Type", value: formData.kycData.idType },
-                    { label: "ID Number", value: formData.kycData.idNumber },
-                    { label: "Address", value: formData.kycData.address },
-                    ...(isQII ? [{ label: "Proof of Address", value: formData.kycData.addressFile }] : []),
-                    { label: "Selfie", value: formData.kycData.selfie ? "Uploaded" : "Pending" },
+                    { label: "ID Type", value: formatTextField(formData.kycData.idType) },
+                    { label: "ID Number", value: formatTextField(formData.kycData.idNumber) },
+                    { label: "Address", value: formatTextField(formData.kycData.address) },
+                    ...(isQII ? [{ label: "Proof of Address", value: formatUploadField(formData.kycData.addressFile) }] : []),
+                    { label: "Selfie", value: formatUploadField(formData.kycData.selfie) },
                 ]}
             />
 
@@ -114,13 +124,13 @@ export function CorporateInvestorReview() {
                 isStatusType
                 onEditClick={() => handleEdit("kyc")}
                 items={[
-                    { label: "Government ID", value: formData.kycData.idFile },
-                    { label: "Proof of Address", value: formData.kycData.addressFile },
-                    { label: "Recent status report document", value: formData.kycData.statusReport },
+                    { label: "Government ID", value: formatUploadField(formData.kycData.idFile) },
+                    { label: "Proof of Address", value: formatUploadField(formData.kycData.addressFile) },
+                    { label: "Recent status report document", value: formatUploadField(formData.kycData.statusReport) },
                     ...(isQII
-                        ? [{ label: "Proof of QII License", value: formData.kycData.qiiLicense }]
-                        : [{ label: "Incorporation Certificate", value: formData.kycData.incorporationCertificate }]),
-                    { label: "Board Resolution", value: formData.kycData.boardResolution },
+                        ? [{ label: "Proof of QII License", value: formatUploadField(formData.kycData.qiiLicense) }]
+                        : [{ label: "Incorporation Certificate", value: formatUploadField(formData.kycData.incorporationCertificate) }]),
+                    { label: "Board Resolution", value: formatUploadField(formData.kycData.boardResolution) },
                 ]}
             />
 

--- a/src/components/onboarding/organisms/kyc/IdentityVerification.tsx
+++ b/src/components/onboarding/organisms/kyc/IdentityVerification.tsx
@@ -97,6 +97,17 @@ export function IdentityVerification({ onNext, onBack }: IdentityVerificationPro
                 return;
             }
 
+            if (!isFundraiser) {
+                if (subStep === 0 && !isStep0Valid) {
+                    setShowErrors(true);
+                    return;
+                }
+                if (subStep === 1 && !isStep1Valid) {
+                    setShowErrors(true);
+                    return;
+                }
+            }
+
             setSubStep(subStep + 1);
         } else {
             const isCurrentFlowValid = isFundraiser

--- a/src/components/secondary-market/molecules/coming-soon-banner.tsx
+++ b/src/components/secondary-market/molecules/coming-soon-banner.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export function ComingSoonBanner() {
+  return (
+    <div
+      role="status"
+      className="w-full bg-[#FFF8E6] border-b border-[#E8D48B] px-4 py-3 text-center text-[#5C4A00] text-sm font-medium"
+      style={{ fontFamily: "var(--font-dm-sans)" }}
+    >
+      Coming soon — secondary market trading is not available yet.
+    </div>
+  );
+}

--- a/src/components/secondary-market/organisms/HowToInvest.tsx
+++ b/src/components/secondary-market/organisms/HowToInvest.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/components/ui/button'
 import { ArrowRight } from 'lucide-react'
-import Link from 'next/link'
 import Image from 'next/image'
 import React from 'react'
 
@@ -63,8 +62,8 @@ export function HowToInvest() {
                     </p>
 
                     <div className="flex items-center justify-center md:justify-start">
-                        <Button className="rounded-lg h-16 px-4 gap-2 flex flex-row items-center justify-between w-full transition-all 
-                                        bg-[#F2F1FE] hover:bg-[#7A6FF0]/90 text-[#5C53B4] border border-[#7A6FF0]"
+                        <Button className="rounded-lg h-16 px-4 gap-2 flex flex-row items-center justify-between w-full transition-all opacity-60 cursor-not-allowed
+                                        bg-[#F2F1FE] text-[#5C53B4] border border-[#7A6FF0]"
                             style={{
                                 fontFamily: 'var(--font-rethink-sans)',
                                 fontWeight: 500,
@@ -72,11 +71,14 @@ export function HowToInvest() {
                                 lineHeight: '21px',
                                 width: '287px',
                             }}
-                            asChild >
-                            <Link href="/invest-now" className="flex items-center justify-between w-full">
+                            type="button"
+                            disabled
+                            aria-disabled
+                        >
+                            <span className="flex items-center justify-between w-full">
                                 <span>Invest Now</span>
                                 <ArrowRight className="h-7 w-7" strokeWidth={2.5} />
-                            </Link>
+                            </span>
                         </Button>
                     </div>
                 </div>

--- a/src/components/secondary-market/organisms/SecondaryMarketHero.tsx
+++ b/src/components/secondary-market/organisms/SecondaryMarketHero.tsx
@@ -52,8 +52,8 @@ export function SecondaryMarketHero() {
                             aria-disabled
                             className={`rounded-lg h-16 px-4 gap-2 flex flex-row items-center justify-between w-full transition-all opacity-60 cursor-not-allowed
                                         ${action.variant === 'primary'
-                                    ? "bg-[#7A6FF0] hover:bg-[#7A6FF0]/90 text-white"
-                                    : "bg-[#F2F1FE] hover:bg-[#7A6FF0]/90 text-[#5C53B4] border border-[#7A6FF0]"}`}
+                                    ? "bg-[#7A6FF0] text-white"
+                                    : "bg-[#F2F1FE] text-[#5C53B4] border border-[#7A6FF0]"}`}
                             style={{
                                 fontFamily: 'var(--font-rethink-sans)',
                                 fontWeight: 500,

--- a/src/components/secondary-market/organisms/SecondaryMarketHero.tsx
+++ b/src/components/secondary-market/organisms/SecondaryMarketHero.tsx
@@ -48,7 +48,9 @@ export function SecondaryMarketHero() {
                     {buttonDetails.map((action, index) => (
                         <Button
                             key={index}
-                            className={`rounded-lg h-16 px-4 gap-2 flex flex-row items-center justify-between w-full transition-all
+                            disabled
+                            aria-disabled
+                            className={`rounded-lg h-16 px-4 gap-2 flex flex-row items-center justify-between w-full transition-all opacity-60 cursor-not-allowed
                                         ${action.variant === 'primary'
                                     ? "bg-[#7A6FF0] hover:bg-[#7A6FF0]/90 text-white"
                                     : "bg-[#F2F1FE] hover:bg-[#7A6FF0]/90 text-[#5C53B4] border border-[#7A6FF0]"}`}

--- a/src/components/secondary-market/organisms/TradeWithConfidence.tsx
+++ b/src/components/secondary-market/organisms/TradeWithConfidence.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/components/ui/button'
 import { ArrowRight } from 'lucide-react'
-import Link from 'next/link'
 import Image from 'next/image'
 import React from 'react'
 import { cn } from '@/lib/utils'
@@ -110,8 +109,10 @@ export function TradeWithConfidence({
                         {/* Button */}
                         <div>
                             <Button
+                                disabled
+                                aria-disabled
                                 className={cn(
-                                    'group rounded-lg px-4 flex flex-row items-center justify-between transition-all text-white',
+                                    'group rounded-lg px-4 flex flex-row items-center justify-between transition-all text-white opacity-60 cursor-not-allowed',
                                     hasImages
                                         ? 'bg-[#B9C65B] h-[64px] w-[287px] gap-[74px] hover:bg-[#7A6FF0]'
                                         : 'bg-[#B9C65B] h-[48px] w-[242px]'
@@ -122,18 +123,16 @@ export function TradeWithConfidence({
                                     fontSize: '16px',
                                     lineHeight: '21px',
                                 }}
-                                asChild
+                                type="button"
                             >
-                                <Link href="/go-to-secondary-market" className="flex items-center justify-between w-full">
-                                    <span
-                                        className={cn(
-                                            !hasImages && 'group-hover:text-black'
-                                        )}
-                                    >
-                                        Go to Secondary Market
-                                    </span>
-                                    <ArrowRight className="h-7 w-7" strokeWidth={2.5} />
-                                </Link>
+                                <span
+                                    className={cn(
+                                        !hasImages && 'group-hover:text-black'
+                                    )}
+                                >
+                                    Go to Secondary Market
+                                </span>
+                                <ArrowRight className="h-7 w-7" strokeWidth={2.5} />
                             </Button>
                         </div>
                     </div>

--- a/src/components/secondary-market/organisms/TradeWithConfidence.tsx
+++ b/src/components/secondary-market/organisms/TradeWithConfidence.tsx
@@ -114,7 +114,7 @@ export function TradeWithConfidence({
                                 className={cn(
                                     'group rounded-lg px-4 flex flex-row items-center justify-between transition-all text-white opacity-60 cursor-not-allowed',
                                     hasImages
-                                        ? 'bg-[#B9C65B] h-[64px] w-[287px] gap-[74px] hover:bg-[#7A6FF0]'
+                                        ? 'bg-[#B9C65B] h-[64px] w-[287px] gap-[74px]'
                                         : 'bg-[#B9C65B] h-[48px] w-[242px]'
                                 )}
                                 style={{
@@ -125,11 +125,7 @@ export function TradeWithConfidence({
                                 }}
                                 type="button"
                             >
-                                <span
-                                    className={cn(
-                                        !hasImages && 'group-hover:text-black'
-                                    )}
-                                >
+                                <span>
                                     Go to Secondary Market
                                 </span>
                                 <ArrowRight className="h-7 w-7" strokeWidth={2.5} />

--- a/src/hooks/use-login.ts
+++ b/src/hooks/use-login.ts
@@ -7,6 +7,8 @@ import { CACHE_KEY_USER } from "@/constants";
 import { tokenStorage } from "@/lib/token-storage";
 import { showApiErrorToast } from "@/lib/error-feedback";
 import { resolvePostLoginPath } from "@/lib/post-login-navigation";
+import { mapApiUserTypeToStoreUserType } from "@/lib/user-type";
+import { useUserStore } from "@/store/userStore";
 
 export type { LoginRequest, LoginResponse };
 
@@ -26,6 +28,13 @@ const useLogin = (options?: UseLoginOptions) => {
       tokenStorage.setAccessToken(data.token, persistent);
       if (data.refreshToken)
         tokenStorage.setRefreshToken(data.refreshToken, persistent);
+
+      useUserStore.getState().setUserId(String(data.userId));
+      useUserStore.getState().updateProfile({
+        emailAddress: data.email,
+        userType: mapApiUserTypeToStoreUserType(data.userType),
+      });
+
       queryClient.invalidateQueries({ queryKey: CACHE_KEY_USER });
 
       const path = await resolvePostLoginPath(data, {

--- a/src/hooks/use-logout.ts
+++ b/src/hooks/use-logout.ts
@@ -6,6 +6,7 @@ import authService from "@/services/authService";
 import { CACHE_KEY_USER } from "@/constants";
 import { tokenStorage } from "@/lib/token-storage";
 import { showApiErrorToast } from "@/lib/error-feedback";
+import { useUserStore } from "@/store/userStore";
 
 const useLogout = () => {
   const router = useRouter();
@@ -16,6 +17,7 @@ const useLogout = () => {
     mutationFn: authService.logout,
     onSuccess: () => {
       tokenStorage.clear();
+      useUserStore.getState().clearUser();
       queryClient.invalidateQueries({ queryKey: CACHE_KEY_USER });
       router.push("/sign-in");
     },

--- a/src/hooks/use-watchlist.ts
+++ b/src/hooks/use-watchlist.ts
@@ -11,12 +11,13 @@ export function useWatchlist() {
 }
 
 export function useWatchlistStatus(offeringId: number, enabled = true) {
-  const isAuthenticated = Boolean(tokenStorage.getAccessToken());
+  // Skip auth-only status fetch for guests (avoids 401). Click-time redirect lives in the panel.
+  const hasSession = Boolean(tokenStorage.getAccessToken());
 
   return useQuery({
     queryKey: [...CACHE_KEY_WATCHLIST, "status", offeringId],
     queryFn: () => watchlistService.getWatchlistStatus(offeringId),
-    enabled: enabled && isAuthenticated && offeringId > 0,
+    enabled: enabled && hasSession && offeringId > 0,
   });
 }
 

--- a/src/hooks/use-watchlist.ts
+++ b/src/hooks/use-watchlist.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_KEY_WATCHLIST } from "@/constants";
+import { tokenStorage } from "@/lib/token-storage";
 import watchlistService from "@/services/watchlistService";
 
 export function useWatchlist() {
@@ -10,10 +11,12 @@ export function useWatchlist() {
 }
 
 export function useWatchlistStatus(offeringId: number, enabled = true) {
+  const isAuthenticated = Boolean(tokenStorage.getAccessToken());
+
   return useQuery({
     queryKey: [...CACHE_KEY_WATCHLIST, "status", offeringId],
     queryFn: () => watchlistService.getWatchlistStatus(offeringId),
-    enabled: enabled && offeringId > 0,
+    enabled: enabled && isAuthenticated && offeringId > 0,
   });
 }
 

--- a/src/lib/post-login-navigation.ts
+++ b/src/lib/post-login-navigation.ts
@@ -2,6 +2,7 @@ import type { LoginResponse } from "@/services/authService";
 import { ONBOARDING_CONFIG, type InvestorUserType } from "@/constants/steps";
 import onboardingService from "@/services/onboardingService";
 import { mapOnboardingStepToUiStep } from "@/lib/onboarding-hydration";
+import { mapApiUserTypeToStoreUserType } from "@/lib/user-type";
 import type { OnboardingResponse } from "@/types/onboarding";
 import {
   buildCheckoutPath,
@@ -11,11 +12,7 @@ import {
 
 /** Maps API login `userType` (camelCase or PascalCase) to onboarding URL segment. */
 export function mapLoginUserTypeToInvestorPathSegment(userType: string): InvestorUserType {
-  const t = userType.trim();
-  if (t === "IndividualInvestor" || t === "individualInvestor") return "individual";
-  if (t === "CorporateInvestor" || t === "corporateInvestor") return "corporate";
-  if (t === "FundRaiser" || t === "fundRaiser") return "fundraiser";
-  return "individual";
+  return mapApiUserTypeToStoreUserType(userType);
 }
 
 function firstStepKeyForType(type: InvestorUserType): string {

--- a/src/lib/share-page.ts
+++ b/src/lib/share-page.ts
@@ -1,0 +1,24 @@
+import { toast } from "sonner";
+
+export async function shareCurrentPage(title?: string): Promise<void> {
+  if (typeof window === "undefined") return;
+
+  const url = window.location.href;
+  const shareTitle = title ?? document.title;
+
+  if (navigator.share) {
+    try {
+      await navigator.share({ url, title: shareTitle });
+      return;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+    }
+  }
+
+  try {
+    await navigator.clipboard.writeText(url);
+    toast.success("Link copied to clipboard");
+  } catch {
+    toast.error("Unable to share this page");
+  }
+}

--- a/src/lib/user-type.ts
+++ b/src/lib/user-type.ts
@@ -1,0 +1,10 @@
+import type { UserType } from "@/store/userStore";
+
+/** Maps API login/profile `userType` to persisted store value. */
+export function mapApiUserTypeToStoreUserType(apiUserType: string): UserType {
+  const t = apiUserType.trim();
+  if (t === "IndividualInvestor" || t === "individualInvestor") return "individual";
+  if (t === "CorporateInvestor" || t === "corporateInvestor") return "corporate";
+  if (t === "FundRaiser" || t === "fundRaiser" || t === "Fundraiser") return "fundraiser";
+  return "individual";
+}

--- a/src/lib/user-type.ts
+++ b/src/lib/user-type.ts
@@ -2,9 +2,11 @@ import type { UserType } from "@/store/userStore";
 
 /** Maps API login/profile `userType` to persisted store value. */
 export function mapApiUserTypeToStoreUserType(apiUserType: string): UserType {
-  const t = apiUserType.trim();
-  if (t === "IndividualInvestor" || t === "individualInvestor") return "individual";
-  if (t === "CorporateInvestor" || t === "corporateInvestor") return "corporate";
-  if (t === "FundRaiser" || t === "fundRaiser" || t === "Fundraiser") return "fundraiser";
+  const normalized = apiUserType.trim().toLowerCase().replace(/[\s_-]/g, "");
+
+  if (normalized === "individualinvestor" || normalized === "individual") return "individual";
+  if (normalized === "corporateinvestor" || normalized === "corporate") return "corporate";
+  if (normalized === "fundraiser") return "fundraiser";
+
   return "individual";
 }

--- a/src/services/api-interceptors.ts
+++ b/src/services/api-interceptors.ts
@@ -69,6 +69,11 @@ export function setupInterceptors(instance: AxiosInstance): void {
       ) {
         return Promise.reject(err);
       }
+      // Guests hitting auth-only endpoints: reject without forcing login redirect
+      if (!tokenStorage.getRefreshToken()) {
+        tokenStorage.clear();
+        return Promise.reject(err);
+      }
       const now = Date.now();
       if (
         refreshFailureTime !== null &&

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -34,7 +34,7 @@ export const useUserStore = create<UserState>()(
             city: null,
             state: null,
             profilePictureUrl: null,
-            userType: "fundraiser",
+            userType: "individual",
             isKycCompleted: false,
 
             setUserId: (id) => set(() => ({ userId: id })),
@@ -50,7 +50,7 @@ export const useUserStore = create<UserState>()(
                 city: null,
                 state: null,
                 profilePictureUrl: null,
-                userType: "fundraiser",
+                userType: "individual",
                 isKycCompleted: false,
             })),
         }),


### PR DESCRIPTION
## Summary
- Keep explore/campaign details public for guests; fix broken marketing CTAs and make secondary market Coming Soon (inert actions).
- Sync `userType` from login/API into local storage so investor vs fundraiser dashboards render correctly.
- Harden KYC step validation, wire guest share/watchlist actions, and fix portfolio chart toggle + currency alignment; rename sidebar to Marketplace.

## Test plan
- [x] Guest: landing Invest Now / Apply → `/create-account` (no 404)
- [x] Guest: secondary Start trading → `/secondary-market` with Coming Soon; page buttons do nothing
- [x] Guest: View Details stays on `/explore/{slug}` (no forced login); Share works; Watchlist → sign-in
- [x] About: Explore Investment → `/explore`
- [x] Login as individual investor → investor sidebar/dashboard (not fundraiser)
- [x] Login as fundraiser → fundraiser nav/dashboard
- [x] KYC non-skip: cannot advance past first 2 stages empty; review shows Pending when empty
- [x] Dashboard: toggle Portfolio Stat ↔ Investment dist both ways; chart uses ₦ / holdings data
- [x] Sidebar shows Marketplace


Made with [Cursor](https://cursor.com)