### PR TITLE
Improve onboarding resume, logout, and landing session UX

### DIFF
--- a/src/app/(auth)/onboarding/[investorUserType]/[step]/OnboardingClient.tsx
+++ b/src/app/(auth)/onboarding/[investorUserType]/[step]/OnboardingClient.tsx
@@ -5,11 +5,15 @@ import { useRouter } from "next/navigation"
 import StepRenderer from "@/components/onboarding/organisms/StepRenderer"
 import { ONBOARDING_CONFIG, StepKey, isKnownOnboardingStep, InvestorUserType, isInvestorUserType, ALLOWED_STEP_BEFORE_VERIFICATION } from "@/constants/steps"
 import { AllowedStepBeforeVerify, useOnboardingStore } from "@/store/onboardingStore"
+import { useUserStore } from "@/store/userStore"
 import { tokenStorage } from "@/lib/token-storage"
+import { getUserIdFromAccessToken } from "@/lib/jwt"
 import authService from "@/services/authService"
 import onboardingService from "@/services/onboardingService"
+import userService from "@/services/userService"
 import {
     buildFormPatchFromOnboarding,
+    buildFormPatchFromUserProfile,
     mapOnboardingStepToUiStep,
 } from "@/lib/onboarding-hydration"
 
@@ -33,7 +37,8 @@ export function OnboardingClient({ step, investorUserType }: Props) {
         emailVerified,
         setEmailVerified,
         setInvestorUserType,
-        updateFormData
+        updateFormData,
+        formData,
     } = useOnboardingStore()
     const [isAuthResolved, setIsAuthResolved] = useState(false);
     const [isHydrationResolved, setIsHydrationResolved] = useState(false);
@@ -56,12 +61,6 @@ export function OnboardingClient({ step, investorUserType }: Props) {
         let cancelled = false;
 
         const bootstrapAuth = async () => {
-            // Only bootstrap refresh when user is trying to access steps that require verification.
-            if (!configData.REQUIRING_VERIFICATION.includes(stepKey)) {
-                if (!cancelled) setIsAuthResolved(true);
-                return;
-            }
-
             const refreshToken = tokenStorage.getRefreshToken();
             if (!refreshToken) {
                 if (!cancelled) setIsAuthResolved(true);
@@ -74,6 +73,10 @@ export function OnboardingClient({ step, investorUserType }: Props) {
                 if (data.refreshToken) tokenStorage.setRefreshToken(data.refreshToken);
                 if (!cancelled) {
                     setEmailVerified(data.isEmailVerified);
+                    useUserStore.getState().updateProfile({
+                        isEmailVerified: data.isEmailVerified,
+                        emailAddress: data.email,
+                    });
                 }
             } catch {
                 // Ignore bootstrap errors; existing route guard will handle access.
@@ -87,7 +90,7 @@ export function OnboardingClient({ step, investorUserType }: Props) {
         return () => {
             cancelled = true;
         };
-    }, [setEmailVerified, configData, stepKey]);
+    }, [setEmailVerified, stepKey]);
 
     useEffect(() => {
         let cancelled = false;
@@ -95,14 +98,7 @@ export function OnboardingClient({ step, investorUserType }: Props) {
         const hydrateOnboarding = async () => {
             if (!isAuthResolved) return;
 
-            // Hydration contract now supports individual, corporate and fundraiser.
-            if ((type !== "individual" && type !== "corporate" && type !== "fundraiser") || !emailVerified) {
-                if (!cancelled) setIsHydrationResolved(true);
-                return;
-            }
-
-            // Hydrate only for steps after verification.
-            if (!configData.REQUIRING_VERIFICATION.includes(stepKey)) {
+            if (type !== "individual" && type !== "corporate" && type !== "fundraiser") {
                 if (!cancelled) setIsHydrationResolved(true);
                 return;
             }
@@ -110,11 +106,36 @@ export function OnboardingClient({ step, investorUserType }: Props) {
             if (!cancelled) setIsHydrationResolved(false);
 
             try {
-                const onboarding = await onboardingService.getOnboarding();
-                if (!cancelled) {
-                    updateFormData(buildFormPatchFromOnboarding(onboarding));
-                    const serverStep = mapOnboardingStepToUiStep(onboarding.currentStep, type);
-                    setCurrentStep(serverStep);
+                if (emailVerified && configData.REQUIRING_VERIFICATION.includes(stepKey)) {
+                    const onboarding = await onboardingService.getOnboarding();
+                    if (!cancelled) {
+                        updateFormData(buildFormPatchFromOnboarding(onboarding));
+                        const serverStep = mapOnboardingStepToUiStep(onboarding.currentStep, type);
+                        setCurrentStep(serverStep);
+                    }
+                } else if (
+                    configData.ALLOWED_STEP_BEFORE_VERIFICATION.includes(stepKey)
+                    && !formData.email
+                    && !formData.loginEmail
+                    && !formData.firstName
+                    && !formData.companyName
+                ) {
+                    // After logout/login (or store reset), refill signup details from the user API.
+                    const userId = getUserIdFromAccessToken(tokenStorage.getAccessToken());
+                    if (userId != null) {
+                        const profile = await userService.getById(userId);
+                        if (!cancelled) {
+                            updateFormData(buildFormPatchFromUserProfile(profile));
+                            useUserStore.getState().updateProfile({
+                                emailAddress: profile.email,
+                                firstName: profile.firstName,
+                                lastName: profile.lastName,
+                                isEmailVerified: profile.isEmailVerified,
+                                userType: type,
+                            });
+                            setEmailVerified(profile.isEmailVerified);
+                        }
+                    }
                 }
             } catch {
                 // Keep the current route even if hydration fails; user can continue.
@@ -136,6 +157,11 @@ export function OnboardingClient({ step, investorUserType }: Props) {
         stepKey,
         updateFormData,
         setCurrentStep,
+        setEmailVerified,
+        formData.email,
+        formData.loginEmail,
+        formData.firstName,
+        formData.companyName,
     ]);
 
     useEffect(() => {

--- a/src/app/(auth)/onboarding/[investorUserType]/layout.tsx
+++ b/src/app/(auth)/onboarding/[investorUserType]/layout.tsx
@@ -1,4 +1,5 @@
 import OnboardingSidebar from "@/components/onboarding/organisms/onboarding-sidebar/OnboardingSidebar"
+import { OnboardingMobileLogout } from "@/components/onboarding/organisms/OnboardingMobileLogout"
 
 export default function OnboardingLayout({
     children,
@@ -18,6 +19,8 @@ export default function OnboardingLayout({
 
             {/* Main content */}
             <main className="flex flex-1 flex-col min-h-screen items-center bg-white">
+
+                <OnboardingMobileLogout />
 
                 <div className="flex-1 flex flex-col justify-between items-center w-full">
 

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   FileText,
 } from "lucide-react"
 import Image from "next/image"
+import Link from "next/link"
 
 import { NavMain } from "@/components/nav-main"
 import {
@@ -44,7 +45,7 @@ const investorNavGroups = [
       { title: "Access Chat", url: "/access-chat", icon: MessageCircle },
       { title: "Help Center", url: "/help-center", icon: MessageCircleQuestionMark },
       { title: "Settings", url: "/settings", icon: Settings },
-      { title: "Log Out", url: "/log-out", icon: LogOut },
+      { title: "Log Out", url: "#", icon: LogOut, action: "logout" as const },
     ],
   },
 ];
@@ -66,7 +67,7 @@ const fundraiserNavGroups = [
       { title: "Access Chat", url: "/access-chat", icon: MessageCircle },
       { title: "Help Center", url: "/help-center", icon: MessageCircleQuestionMark },
       { title: "Settings", url: "/settings", icon: Settings },
-      { title: "Log Out", url: "/log-out", icon: LogOut },
+      { title: "Log Out", url: "#", icon: LogOut, action: "logout" as const },
     ],
   },
 ];
@@ -80,14 +81,16 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar {...props} className="bg-[#FFFFFF] shrink-0 scrollbar-hide">
       <SidebarHeader className="pt-10 pb-7 bg-[#FFFFFF]">
-        <Image
-          src="/icons/antital.svg"
-          alt="Antital Logo"
-          width={80}
-          height={80}
-          priority
-          className="object-contain"
-        />
+        <Link href="/" aria-label="Antital home" className="inline-flex">
+          <Image
+            src="/icons/antital.svg"
+            alt="Antital Logo"
+            width={80}
+            height={80}
+            priority
+            className="object-contain"
+          />
+        </Link>
       </SidebarHeader>
       <SidebarContent className="flex flex-col justify-between h-full overflow-visible scrollbar-hide bg-[#FFFFFF]">
         {activeNavGroups.map((group) => (

--- a/src/components/auth/sync-user-profile.tsx
+++ b/src/components/auth/sync-user-profile.tsx
@@ -16,6 +16,7 @@ export function SyncUserProfile() {
     updateProfile({
       emailAddress: user.email,
       userType: mapApiUserTypeToStoreUserType(user.userType),
+      isEmailVerified: user.isEmailVerified,
     });
     setUserId(String(user.id));
   }, [user]);

--- a/src/components/landing/organisms/navbar.tsx
+++ b/src/components/landing/organisms/navbar.tsx
@@ -8,8 +8,12 @@ import { Menu, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { useTheme } from '@/hooks/use-theme'
 import { ExploreMenu } from '@/components/landing/organisms/explore-menu'
+import { tokenStorage } from '@/lib/token-storage'
+import { useUserStore } from '@/store/userStore'
+import { resolveSessionResumePath } from '@/lib/post-login-navigation'
 
 // Navigation items based on your Figma design
 const navigationItems = [
@@ -55,11 +59,60 @@ const handleNavClick = (href: string, e: React.MouseEvent, callback?: () => void
   }
 }
 
+function getInitials(firstName: string | null, lastName: string | null, email: string | null): string {
+  const first = firstName?.trim()?.[0]
+  const last = lastName?.trim()?.[0]
+  if (first || last) return `${first ?? ''}${last ?? ''}`.toUpperCase()
+  const fromEmail = email?.trim()?.[0]
+  return (fromEmail ?? 'U').toUpperCase()
+}
+
 export function Navbar() {
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
   const { theme } = useTheme()
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light')
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [appHref, setAppHref] = useState('/dashboard')
+  const [appCtaLabel, setAppCtaLabel] = useState('Go to Dashboard')
+
+  const profilePictureUrl = useUserStore((s) => s.profilePictureUrl)
+  const firstName = useUserStore((s) => s.firstName)
+  const lastName = useUserStore((s) => s.lastName)
+  const emailAddress = useUserStore((s) => s.emailAddress)
+  const isEmailVerified = useUserStore((s) => s.isEmailVerified)
+  const userType = useUserStore((s) => s.userType)
+
+  useEffect(() => {
+    // Tokens exist after signup before email verify — don't treat that as logged-in marketing UI.
+    setIsLoggedIn(Boolean(tokenStorage.getAccessToken()) && isEmailVerified)
+  }, [pathname, isEmailVerified])
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setAppHref('/dashboard')
+      setAppCtaLabel('Go to Dashboard')
+      return
+    }
+
+    let cancelled = false
+    void resolveSessionResumePath({
+      userType,
+      isEmailVerified: true,
+    }).then((resume) => {
+      if (cancelled) return
+      setAppHref(resume.path)
+      setAppCtaLabel(
+        resume.kind === 'onboarding' || resume.kind === 'email'
+          ? 'Continue Onboarding'
+          : 'Go to Dashboard'
+      )
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [isLoggedIn, userType, pathname])
 
   // Resolve system theme to actual light/dark
   useEffect(() => {
@@ -81,6 +134,65 @@ export function Navbar() {
 
   // Choose logo based on theme
   const logoSrc = resolvedTheme === 'dark' ? '/icons/antital-white.svg' : '/icons/antital.svg'
+  const avatarFallback = getInitials(firstName, lastName, emailAddress)
+
+  const guestActions = (
+    <>
+      <Button
+        className="bg-[#365852] hover:bg-[#365852]/90 text-white px-3 lg:px-4 py-2 rounded-lg font-medium h-12 min-w-[100px] lg:min-w-[110px]"
+        asChild
+        style={{
+          fontFamily: 'var(--font-rethink-sans)',
+          fontSize: '15px',
+          lineHeight: '21px',
+          fontWeight: 500,
+        }}
+      >
+        <Link href="/sign-in">Invest now</Link>
+      </Button>
+      <Button
+        variant="outline"
+        className="border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] dark:[&:hover]:bg-[#A7B832] dark:[&:hover]:text-[#11110F] dark:[&:hover]:border-[#A7B832] bg-transparent px-3 lg:px-4 py-2 rounded-lg font-medium h-12 min-w-[105px] lg:min-w-[116px]"
+        asChild
+        style={{
+          fontFamily: 'var(--font-rethink-sans)',
+          fontSize: '15px',
+          lineHeight: '21px',
+          fontWeight: 500,
+        }}
+      >
+        <Link href="/sign-in">Raise funds</Link>
+      </Button>
+    </>
+  )
+
+  const loggedInActions = (
+    <>
+      <Link href={appHref} aria-label={appCtaLabel}>
+        <Avatar className="h-12 w-12 border border-[#EAEAEA] cursor-pointer">
+          {profilePictureUrl ? (
+            <AvatarImage src={profilePictureUrl} alt="User profile" />
+          ) : null}
+          <AvatarFallback className="bg-[#F4F5F7] text-[#042E27] text-sm font-medium">
+            {avatarFallback}
+          </AvatarFallback>
+        </Avatar>
+      </Link>
+      <Button
+        variant="outline"
+        className="border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] bg-transparent px-3 lg:px-4 py-2 rounded-lg font-medium h-12 whitespace-nowrap"
+        asChild
+        style={{
+          fontFamily: 'var(--font-rethink-sans)',
+          fontSize: '15px',
+          lineHeight: '21px',
+          fontWeight: 500,
+        }}
+      >
+        <Link href={appHref}>{appCtaLabel}</Link>
+      </Button>
+    </>
+  )
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-[#EAEAEA] bg-background">
@@ -156,31 +268,7 @@ export function Navbar() {
 
           {/* Account Actions - compact on smaller screens, don't shrink */}
           <div className="hidden lg:flex items-center gap-1.5 shrink-0">
-            <Button
-              className="bg-[#365852] hover:bg-[#365852]/90 text-white px-3 lg:px-4 py-2 rounded-lg font-medium h-12 min-w-[100px] lg:min-w-[110px]"
-              asChild
-              style={{
-                fontFamily: 'var(--font-rethink-sans)',
-                fontSize: '15px',
-                lineHeight: '21px',
-                fontWeight: 500,
-              }}
-            >
-              <Link href="/sign-in">Invest now</Link>
-            </Button>
-            <Button
-              variant="outline"
-              className="border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] dark:[&:hover]:bg-[#A7B832] dark:[&:hover]:text-[#11110F] dark:[&:hover]:border-[#A7B832] bg-transparent px-3 lg:px-4 py-2 rounded-lg font-medium h-12 min-w-[105px] lg:min-w-[116px]"
-              asChild
-              style={{
-                fontFamily: 'var(--font-rethink-sans)',
-                fontSize: '15px',
-                lineHeight: '21px',
-                fontWeight: 500,
-              }}
-            >
-              <Link href="/sign-in">Raise funds</Link>
-            </Button>
+            {isLoggedIn ? loggedInActions : guestActions}
           </div>
 
           {/* Mobile Menu Button - pushed to the right */}
@@ -241,37 +329,72 @@ export function Navbar() {
                 {/* Divider */}
                 <div className="border-t border-[#EAEAEA]" />
 
-                {/* Mobile Actions - Invest now first, then Raise funds */}
+                {/* Mobile Actions */}
                 <div className="flex flex-col gap-3">
-                  <Button
-                    className="w-full h-12 bg-[#365852] hover:bg-[#365852]/90 text-white rounded-lg"
-                    style={{
-                      fontFamily: 'var(--font-rethink-sans)',
-                      fontSize: '16px',
-                      lineHeight: '21px',
-                      fontWeight: 500,
-                    }}
-                    asChild
-                  >
-                    <Link href="/sign-in" onClick={() => setIsOpen(false)}>
-                      Invest now
-                    </Link>
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full h-12 border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] dark:[&:hover]:bg-[#A7B832] dark:[&:hover]:text-[#11110F] dark:[&:hover]:border-[#A7B832] rounded-lg"
-                    style={{
-                      fontFamily: 'var(--font-rethink-sans)',
-                      fontSize: '16px',
-                      lineHeight: '21px',
-                      fontWeight: 500,
-                    }}
-                    asChild
-                  >
-                    <Link href="/sign-in" onClick={() => setIsOpen(false)}>
-                      Raise funds
-                    </Link>
-                  </Button>
+                  {isLoggedIn ? (
+                    <>
+                      <div className="flex items-center gap-3 px-1">
+                        <Avatar className="h-12 w-12 border border-[#EAEAEA]">
+                          {profilePictureUrl ? (
+                            <AvatarImage src={profilePictureUrl} alt="User profile" />
+                          ) : null}
+                          <AvatarFallback className="bg-[#F4F5F7] text-[#042E27] text-sm font-medium">
+                            {avatarFallback}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="text-[16px] text-[#2C2C2C]" style={{ fontFamily: 'var(--font-dm-sans)' }}>
+                          {[firstName, lastName].filter(Boolean).join(' ') || emailAddress || 'Account'}
+                        </span>
+                      </div>
+                      <Button
+                        variant="outline"
+                        className="w-full h-12 border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] rounded-lg"
+                        style={{
+                          fontFamily: 'var(--font-rethink-sans)',
+                          fontSize: '16px',
+                          lineHeight: '21px',
+                          fontWeight: 500,
+                        }}
+                        asChild
+                      >
+                        <Link href={appHref} onClick={() => setIsOpen(false)}>
+                          {appCtaLabel}
+                        </Link>
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button
+                        className="w-full h-12 bg-[#365852] hover:bg-[#365852]/90 text-white rounded-lg"
+                        style={{
+                          fontFamily: 'var(--font-rethink-sans)',
+                          fontSize: '16px',
+                          lineHeight: '21px',
+                          fontWeight: 500,
+                        }}
+                        asChild
+                      >
+                        <Link href="/sign-in" onClick={() => setIsOpen(false)}>
+                          Invest now
+                        </Link>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        className="w-full h-12 border-[#A8A8A8] text-foreground [&:hover]:bg-[#A7B832] [&:hover]:text-[#11110F] [&:hover]:border-[#A7B832] dark:[&:hover]:bg-[#A7B832] dark:[&:hover]:text-[#11110F] dark:[&:hover]:border-[#A7B832] rounded-lg"
+                        style={{
+                          fontFamily: 'var(--font-rethink-sans)',
+                          fontSize: '16px',
+                          lineHeight: '21px',
+                          fontWeight: 500,
+                        }}
+                        asChild
+                      >
+                        <Link href="/sign-in" onClick={() => setIsOpen(false)}>
+                          Raise funds
+                        </Link>
+                      </Button>
+                    </>
+                  )}
                 </div>
               </div>
             </SheetContent>
@@ -281,4 +404,3 @@ export function Navbar() {
     </header>
   )
 }
-

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -19,29 +19,34 @@ import {
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar"
 import { cn } from "@/lib/utils"
+import useLogout from "@/hooks/use-logout"
+
+export type NavMainItem = {
+  title: string
+  url: string
+  icon?: React.ComponentType<React.ComponentProps<"svg">>
+  iconClassName?: string
+  isActive?: boolean
+  action?: "logout"
+  items?: {
+    title: string
+    url: string
+    isActive?: boolean
+  }[]
+}
 
 export function NavMain({
   label,
   items,
 }: {
   label?: string
-  items: {
-    title: string
-    url: string
-    icon?: React.ComponentType<React.ComponentProps<"svg">>
-    iconClassName?: string
-    isActive?: boolean
-    items?: {
-      title: string
-      url: string
-      isActive?: boolean
-    }[]
-  }[]
+  items: NavMainItem[]
 }) {
   const pathname = usePathname()
+  const logoutMutation = useLogout()
 
   // Check if any subitem is active to determine if parent should be open
-  const shouldBeOpen = (item: typeof items[0]) => {
+  const shouldBeOpen = (item: NavMainItem) => {
     if (item.isActive) return true
     return item.items?.some(subItem => pathname === subItem.url) || false
   }
@@ -97,6 +102,20 @@ export function NavMain({
                     </SidebarMenuSub>
                   </CollapsibleContent>
                 </>
+              ) : item.action === "logout" ? (
+                <SidebarMenuButton
+                  tooltip={item.title}
+                  className="cursor-pointer"
+                  disabled={logoutMutation.isPending}
+                  onClick={() => logoutMutation.mutate()}
+                >
+                  {item.icon && (
+                    <item.icon className={cn("transition-all", item.iconClassName)} />
+                  )}
+                  <span className="text-[16px]">
+                    {logoutMutation.isPending ? "Logging out…" : item.title}
+                  </span>
+                </SidebarMenuButton>
               ) : (
                 <SidebarMenuButton
                   asChild

--- a/src/components/onboarding/molecules/CollapsibleUpload.tsx
+++ b/src/components/onboarding/molecules/CollapsibleUpload.tsx
@@ -9,9 +9,18 @@ interface CollapsibleProps {
     isOpen: boolean;
     onToggle: () => void;
     value: File | null;
+    documentsOnly?: boolean;
 }
 
-export const CollapsibleUpload = ({ title, onUpload, isError, isOpen, onToggle, value }: CollapsibleProps) => (
+export const CollapsibleUpload = ({
+    title,
+    onUpload,
+    isError,
+    isOpen,
+    onToggle,
+    value,
+    documentsOnly = false,
+}: CollapsibleProps) => (
     <div className="space-y-1 pt-4 border-b border-gray-50">
         <div
             className="flex justify-between items-center cursor-pointer group"
@@ -33,6 +42,7 @@ export const CollapsibleUpload = ({ title, onUpload, isError, isOpen, onToggle, 
                 value={value}
                 onUpload={onUpload}
                 isError={isError}
+                documentsOnly={documentsOnly}
             />
         </div>
     </div>

--- a/src/components/onboarding/molecules/UploadSection.tsx
+++ b/src/components/onboarding/molecules/UploadSection.tsx
@@ -1,8 +1,26 @@
 "use client"
 
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import { Info, Upload, FileText, X } from 'lucide-react'
 import { TYPOGRAPHY } from '@/constants/styles'
+
+const DEFAULT_ACCEPT = "image/jpeg,image/png,application/pdf"
+const DOCUMENT_ACCEPT =
+  "application/pdf,.pdf,application/vnd.ms-powerpoint,.ppt,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pptx"
+
+const DOCUMENT_MIME_TYPES = new Set([
+  "application/pdf",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+])
+
+const DOCUMENT_EXTENSIONS = [".pdf", ".ppt", ".pptx"]
+
+function isAllowedDocument(file: File): boolean {
+  if (DOCUMENT_MIME_TYPES.has(file.type)) return true
+  const lower = file.name.toLowerCase()
+  return DOCUMENT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
 
 interface UploadSectionProps {
     label?: string;
@@ -10,25 +28,57 @@ interface UploadSectionProps {
     onUpload?: (file: File | null) => void;
     isError?: boolean;
     value?: File | null;
+    /** File picker accept list. Defaults to images + PDF (KYC). */
+    accept?: string;
+    /** Helper text under the drop zone. */
+    helperText?: string;
+    /** When true, only PDF / PowerPoint files are accepted. */
+    documentsOnly?: boolean;
 }
 
-export function UploadSection({ label, desc, onUpload, isError, value }: UploadSectionProps) {
+export function UploadSection({
+    label,
+    desc,
+    onUpload,
+    isError,
+    value,
+    accept,
+    helperText,
+    documentsOnly = false,
+}: UploadSectionProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const [typeError, setTypeError] = useState<string | null>(null);
+
+    const resolvedAccept = accept ?? (documentsOnly ? DOCUMENT_ACCEPT : DEFAULT_ACCEPT);
+    const resolvedHelper =
+        helperText ??
+        (documentsOnly
+            ? "Click here to upload, or drag and drop files (PDF and PowerPoint are supported)"
+            : "Click here to upload, or drag and drop files (JPG's and PNG's are supported)");
 
     const handleContainerClick = () => {
         fileInputRef.current?.click();
     };
 
-    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const selectedFile = e.target.files?.[0];
-        if (selectedFile) {
-            onUpload?.(selectedFile);
-            e.target.value = '';
+    const applyFile = (selectedFile: File | undefined) => {
+        if (!selectedFile) return;
+        if (documentsOnly && !isAllowedDocument(selectedFile)) {
+            setTypeError("Please upload a PDF or PowerPoint file (.pdf, .ppt, .pptx)");
+            onUpload?.(null);
+            return;
         }
+        setTypeError(null);
+        onUpload?.(selectedFile);
+    };
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        applyFile(e.target.files?.[0]);
+        e.target.value = '';
     };
 
     const clearFile = (e: React.MouseEvent) => {
         e.stopPropagation();
+        setTypeError(null);
         onUpload?.(null);
         if (fileInputRef.current) fileInputRef.current.value = "";
     };
@@ -39,14 +89,12 @@ export function UploadSection({ label, desc, onUpload, isError, value }: UploadS
 
     const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
         e.preventDefault();
-        const droppedFile = e.dataTransfer.files?.[0];
-        if (droppedFile) {
-            onUpload?.(droppedFile);
-        }
+        applyFile(e.dataTransfer.files?.[0]);
     };
 
     // Safely detect if we have a file and it has a name property
     const hasFile = value instanceof File || (value && typeof value === 'object' && 'name' in value);
+    const showError = (isError && !hasFile) || Boolean(typeError);
 
     return (
         <div className="space-y-2">
@@ -54,7 +102,7 @@ export function UploadSection({ label, desc, onUpload, isError, value }: UploadS
                 type="file"
                 ref={fileInputRef}
                 onChange={handleFileChange}
-                accept="image/jpeg,image/png,application/pdf"
+                accept={resolvedAccept}
                 className="hidden"
             />
 
@@ -78,14 +126,14 @@ export function UploadSection({ label, desc, onUpload, isError, value }: UploadS
                     border-2 border-dashed rounded-xl px-10 py-[72px] flex flex-col items-center justify-center 
                     transition-all cursor-pointer bg-white text-center
                     ${hasFile ? 'border-[#A7B832] bg-[#F9FAF5]' : 'border-[#E6EEDC] hover:bg-gray-50'}
-                    ${isError && !hasFile ? 'border-red-500 bg-red-50' : ''} 
+                    ${showError ? 'border-red-500 bg-red-50' : ''} 
                 `}
             >
                 {!hasFile ? (
                     <>
-                        <Upload className={`w-8 h-8 mb-3 ${isError ? 'text-red-400' : 'text-gray-400'}`} />
-                        <p className={`text-[14px] max-w-[446px] ${isError ? 'text-red-500' : 'text-gray-500'}`} style={TYPOGRAPHY.body}>
-                            Click here to upload, or drag and drop files (JPG&apos;s and PNG&apos;s are supported)
+                        <Upload className={`w-8 h-8 mb-3 ${showError ? 'text-red-400' : 'text-gray-400'}`} />
+                        <p className={`text-[14px] max-w-[446px] ${showError ? 'text-red-500' : 'text-gray-500'}`} style={TYPOGRAPHY.body}>
+                            {resolvedHelper}
                         </p>
                     </>
                 ) : (
@@ -113,10 +161,14 @@ export function UploadSection({ label, desc, onUpload, isError, value }: UploadS
                 )}
             </div>
 
-            <div className={`flex items-center gap-3 p-3 rounded-lg border ${isError && !hasFile ? 'bg-red-50 border-red-100' : 'bg-[#F0F7FF] border-[#D1E4F9]'}`}>
-                <Info className={`w-5 h-5 shrink-0 ${isError && !hasFile ? 'text-red-500' : 'text-[#3E82D5]'}`} />
-                <p className={`text-[12px] ${isError && !hasFile ? 'text-red-500' : 'text-[#3E82D5]'}`} style={TYPOGRAPHY.body}>
-                    {isError && !hasFile ? "This document is required to proceed" : "Ensure the document is clear and all information is visible"}
+            <div className={`flex items-center gap-3 p-3 rounded-lg border ${showError ? 'bg-red-50 border-red-100' : 'bg-[#F0F7FF] border-[#D1E4F9]'}`}>
+                <Info className={`w-5 h-5 shrink-0 ${showError ? 'text-red-500' : 'text-[#3E82D5]'}`} />
+                <p className={`text-[12px] ${showError ? 'text-red-500' : 'text-[#3E82D5]'}`} style={TYPOGRAPHY.body}>
+                    {typeError
+                        ? typeError
+                        : isError && !hasFile
+                            ? "This document is required to proceed"
+                            : "Ensure the document is clear and all information is visible"}
                 </p>
             </div>
         </div>

--- a/src/components/onboarding/organisms/EmailStep.tsx
+++ b/src/components/onboarding/organisms/EmailStep.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { Info } from 'lucide-react'
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton'
@@ -8,10 +8,14 @@ import { useOnboardingStore } from '@/store/onboardingStore'
 import { tokenStorage } from '@/lib/token-storage'
 import authService from '@/services/authService'
 import onboardingService from '@/services/onboardingService'
+import userService from '@/services/userService'
 import { ApiError } from '@/lib/api-error'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { buildFormPatchFromOnboarding, mapOnboardingStepToUiStep } from '@/lib/onboarding-hydration'
+import { useUserStore } from '@/store/userStore'
+import { useCurrentUser } from '@/hooks/use-current-user'
+import { getUserIdFromAccessToken } from '@/lib/jwt'
 import {
     Dialog,
     DialogContent,
@@ -43,7 +47,9 @@ const fundraiserMessage = {
 }
 
 export function EmailStep({ onNext }: EmailStepProps) {
-    const { setEmailVerified, investorUserType, formData, updateFormData, setCurrentStep } = useOnboardingStore()
+    const { setEmailVerified, emailVerified, investorUserType, formData, updateFormData, setCurrentStep } = useOnboardingStore()
+    const storeEmail = useUserStore((s) => s.emailAddress)
+    const { data: currentUser } = useCurrentUser()
     const [isVerifying, setIsVerifying] = useState(false);
     const [isResending, setIsResending] = useState(false);
     const [isRequestingDeleteOtp, setIsRequestingDeleteOtp] = useState(false);
@@ -52,11 +58,60 @@ export function EmailStep({ onNext }: EmailStepProps) {
     const [deleteOtp, setDeleteOtp] = useState("");
     const [deleteDialogStep, setDeleteDialogStep] = useState<"confirm" | "otp">("confirm");
     const router = useRouter();
-    const verificationEmail = (
+
+    const formEmail = (
         investorUserType === "individual"
             ? formData.email
             : formData.loginEmail || formData.email
     )?.trim();
+
+    const verificationEmail = (
+        formEmail
+        || storeEmail?.trim()
+        || currentUser?.email?.trim()
+        || ""
+    );
+
+    // Keep onboarding form in sync when email comes from session/API (e.g. after refresh).
+    useEffect(() => {
+        const email = storeEmail?.trim() || currentUser?.email?.trim();
+        if (!email) return;
+        if (investorUserType === "individual" && !formData.email) {
+            updateFormData({ email });
+        } else if (investorUserType !== "individual" && !formData.loginEmail && !formData.email) {
+            updateFormData({ loginEmail: email, email });
+        }
+    }, [
+        storeEmail,
+        currentUser?.email,
+        investorUserType,
+        formData.email,
+        formData.loginEmail,
+        updateFormData,
+    ]);
+
+    const resolveVerificationEmail = async (): Promise<string | null> => {
+        if (verificationEmail) return verificationEmail;
+
+        const userId = getUserIdFromAccessToken(tokenStorage.getAccessToken());
+        if (userId == null) return null;
+
+        try {
+            const profile = await userService.getById(userId);
+            const email = profile.email?.trim();
+            if (!email) return null;
+
+            useUserStore.getState().updateProfile({ emailAddress: email });
+            if (investorUserType === "individual") {
+                updateFormData({ email });
+            } else {
+                updateFormData({ loginEmail: email, email });
+            }
+            return email;
+        } catch {
+            return null;
+        }
+    };
 
     const handleVerifyEmail = async () => {
         const refreshToken = tokenStorage.getRefreshToken();
@@ -73,6 +128,7 @@ export function EmailStep({ onNext }: EmailStepProps) {
 
             if (data.isEmailVerified) {
                 setEmailVerified(true);
+                useUserStore.getState().updateProfile({ isEmailVerified: true });
 
                 // Hydrate individual and corporate flows from backend progress.
                 if (investorUserType !== "individual" && investorUserType !== "corporate") {
@@ -105,14 +161,15 @@ export function EmailStep({ onNext }: EmailStepProps) {
     }
 
     const handleResendVerification = async () => {
-        if (!verificationEmail) {
-            toast.error("Email address is missing. Go back and complete account details.");
-            return;
-        }
-
         setIsResending(true);
         try {
-            await authService.resendVerification(verificationEmail);
+            const email = await resolveVerificationEmail();
+            if (!email) {
+                toast.error("Email address is missing. Go back and complete account details.");
+                return;
+            }
+
+            await authService.resendVerification(email);
             toast.success("Verification email resent. Check your inbox.");
         } catch (error) {
             if (error instanceof ApiError) toast.error(error.primaryMessage);
@@ -124,14 +181,14 @@ export function EmailStep({ onNext }: EmailStepProps) {
     };
 
     const handleRequestDeleteOtp = async () => {
-        const email = verificationEmail;
-        if (!email) {
-            toast.error("Email address is missing. Go back and complete account details.");
-            return;
-        }
-
         setIsRequestingDeleteOtp(true);
         try {
+            const email = await resolveVerificationEmail();
+            if (!email) {
+                toast.error("Email address is missing. Go back and complete account details.");
+                return;
+            }
+
             await authService.requestUnverifiedOtp({ email });
             toast.success("OTP sent to your email.");
             setDeleteDialogStep("otp");
@@ -145,7 +202,7 @@ export function EmailStep({ onNext }: EmailStepProps) {
     }
 
     const handleDeleteAccountWithOtp = async () => {
-        const email = verificationEmail;
+        const email = await resolveVerificationEmail();
         if (!email) {
             toast.error("Email address is missing. Go back and complete account details.");
             return;
@@ -161,6 +218,7 @@ export function EmailStep({ onNext }: EmailStepProps) {
             await authService.deleteUnverified({ email, otp: deleteOtp });
             tokenStorage.clear();
             setEmailVerified(false);
+            useUserStore.getState().clearUser();
             setShowDeleteConfirm(false);
             setDeleteDialogStep("confirm");
             setDeleteOtp("");
@@ -178,6 +236,38 @@ export function EmailStep({ onNext }: EmailStepProps) {
     const isDeleteBusy = isRequestingDeleteOtp || isDeletingWithOtp;
 
     const isFundraiser = investorUserType === 'fundraiser';
+
+    // Already verified — show continue only (no re-verify / delete account).
+    if (emailVerified) {
+        return (
+            <section>
+                <div className="flex flex-col items-center">
+                    <Image
+                        src="/onboarding/caution-icon.png"
+                        alt="Email verified"
+                        width={80}
+                        height={80}
+                    />
+                    <h4
+                        className="text-[24px] text-[#1F1F1F] leading-none pt-[16px]"
+                        style={{ fontWeight: 500, ...bodyStyle }}
+                    >
+                        Email verified
+                    </h4>
+                    <p
+                        className="text-[16px] text-[#858585] leading-tight py-[8px] text-center max-w-[480px]"
+                        style={bodyStyle}
+                    >
+                        Your email is already verified. You can continue, or use the menu to edit
+                        your personal or company details.
+                    </p>
+                    <div className="w-full max-w-[280px] mt-6">
+                        <OnboardingButton label="Continue" onClick={onNext} />
+                    </div>
+                </div>
+            </section>
+        );
+    }
 
     return (
         <section>

--- a/src/components/onboarding/organisms/OnboardingMobileLogout.tsx
+++ b/src/components/onboarding/organisms/OnboardingMobileLogout.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import useLogout from "@/hooks/use-logout"
+
+/** Mobile-only logout — desktop uses the onboarding sidebar control. */
+export function OnboardingMobileLogout() {
+  const logoutMutation = useLogout()
+
+  return (
+    <div className="lg:hidden w-full flex justify-end px-4 pt-4">
+      <button
+        type="button"
+        onClick={() => logoutMutation.mutate()}
+        disabled={logoutMutation.isPending}
+        className="text-sm text-[#042E27] hover:underline disabled:opacity-60 font-[family-name:var(--font-dm-sans)] cursor-pointer"
+      >
+        {logoutMutation.isPending ? "Logging out…" : "Log out"}
+      </button>
+    </div>
+  )
+}

--- a/src/components/onboarding/organisms/StepRenderer.tsx
+++ b/src/components/onboarding/organisms/StepRenderer.tsx
@@ -41,9 +41,17 @@ export default function StepRenderer({ step, investorUserTypeFromUrl }: StepRend
         }
     };
 
+    // Skip the email step when going back — after verify, return to personal/company.
     const navigateToBack = () => {
-        if (currentIndex > 0) {
-            const prevStepKey = steps[currentIndex - 1].key;
+        if (currentIndex <= 0) return;
+
+        let targetIndex = currentIndex - 1;
+        if (steps[targetIndex]?.key === "email" && targetIndex > 0) {
+            targetIndex -= 1;
+        }
+
+        const prevStepKey = steps[targetIndex]?.key;
+        if (prevStepKey) {
             router.push(`/onboarding/${investorUserTypeFromUrl}/${prevStepKey}`);
         }
     };
@@ -58,12 +66,12 @@ export default function StepRenderer({ step, investorUserTypeFromUrl }: StepRend
             return <EmailStep onNext={navigateToNext} />;
 
         case "company-documentation":
-            return <UploadBusinessDocument />
+            return <UploadBusinessDocument onBack={navigateToBack} />;
 
         case "investor":
-            return <InvestorStep onNext={navigateToNext} />;
+            return <InvestorStep onBack={navigateToBack} onNext={navigateToNext} />;
         case "categorization":
-            return <CorporateCategorization onNext={navigateToNext} />;
+            return <CorporateCategorization onBack={navigateToBack} onNext={navigateToNext} />;
 
         case "profile":
             return <InvestmentProfile onBack={navigateToBack} onNext={navigateToNext} />;

--- a/src/components/onboarding/organisms/corporate/company-step/CompanyInformation.tsx
+++ b/src/components/onboarding/organisms/corporate/company-step/CompanyInformation.tsx
@@ -12,6 +12,8 @@ import { CompanySubStepId, validateFullStep, validateSubStep } from '@/lib/onboa
 import authService from '@/services/authService';
 import { tokenStorage } from '@/lib/token-storage';
 import { showApiErrorToast } from '@/lib/error-feedback';
+import { useUserStore } from '@/store/userStore';
+import { mapApiUserTypeToStoreUserType } from '@/lib/user-type';
 
 const corporateHeaderLabels = [
     { id: 'details', title: 'Corporate Investment Account', desc: 'Register your organization to invest in vetted Nigerian startups' },
@@ -70,6 +72,15 @@ export function CompanyInformation() {
                 return;
             }
 
+            // Account already exists after email verification — keep edits and resume flow.
+            if (store.emailVerified) {
+                const nextAfterEmail = isFundraiser
+                    ? "company-documentation"
+                    : "categorization";
+                router.push(`/onboarding/${investorUserType}/${nextAfterEmail}`);
+                return;
+            }
+
             if (isFundraiser) {
                 setIsSubmitting(true);
                 try {
@@ -110,6 +121,12 @@ export function CompanyInformation() {
                         tokenStorage.setRefreshToken(data.refreshToken);
                     }
                     store.setEmailVerified(data.isEmailVerified);
+                    useUserStore.getState().setUserId(String(data.userId));
+                    useUserStore.getState().updateProfile({
+                        emailAddress: data.email,
+                        userType: mapApiUserTypeToStoreUserType(data.userType),
+                        isEmailVerified: data.isEmailVerified,
+                    });
                     router.push(`/onboarding/${investorUserType}/email`);
                 } catch (error) {
                     showApiErrorToast(error, "Unable to create fundraiser account.");
@@ -166,6 +183,12 @@ export function CompanyInformation() {
                     tokenStorage.setRefreshToken(data.refreshToken);
                 }
                 store.setEmailVerified(data.isEmailVerified);
+                useUserStore.getState().setUserId(String(data.userId));
+                useUserStore.getState().updateProfile({
+                    emailAddress: data.email,
+                    userType: mapApiUserTypeToStoreUserType(data.userType),
+                    isEmailVerified: data.isEmailVerified,
+                });
 
                 router.push(`/onboarding/${investorUserType}/email`);
             } catch (error) {
@@ -216,21 +239,24 @@ export function CompanyInformation() {
                 {renderStepContent()}
             </div>
 
-            <div className="flex items-center justify-between pt-8 pb-10">
-                <OnboardingButton
-                    label='Back'
-                    variant="plain"
-                    disabled={subStep === 0}
-                    onClick={backSubstep}
-                    className="w-[115px]"
-                />
+            <div className={`flex items-center pt-8 pb-10 ${subStep > 0 ? "justify-between" : ""}`}>
+                {subStep > 0 && (
+                    <OnboardingButton
+                        label='Back'
+                        variant="plain"
+                        onClick={backSubstep}
+                        className="w-[115px]"
+                    />
+                )}
 
                 <OnboardingButton
                     label={
                         isLastSubStep
-                            ? isSubmitting
-                                ? "Creating account…"
-                                : "Create Account"
+                            ? store.emailVerified
+                                ? "Save & Continue"
+                                : isSubmitting
+                                    ? "Creating account…"
+                                    : "Create Account"
                             : isSubmitting
                                 ? "Saving…"
                                 : "Proceed"
@@ -238,7 +264,7 @@ export function CompanyInformation() {
                     variant="solid"
                     onClick={nextSubStep}
                     loading={isSubmitting}
-                    className="w-[230px]"
+                    className={subStep > 0 ? "w-[230px]" : undefined}
                 />
             </div>
 

--- a/src/components/onboarding/organisms/corporate/corporate-categorization/CorporateCategorization.tsx
+++ b/src/components/onboarding/organisms/corporate/corporate-categorization/CorporateCategorization.tsx
@@ -16,7 +16,7 @@ const toApiCorporateCategory = (
   return null;
 };
 
-export function CorporateCategorization({ onNext }: { onNext: () => void }) {
+export function CorporateCategorization({ onNext, onBack }: { onNext: () => void; onBack: () => void }) {
 
   const { formData, updateFormData } = useOnboardingStore();
   const [selectedId, setSelectedId] = useState<string | null>(formData.selectedCategoryId || null);
@@ -55,9 +55,9 @@ export function CorporateCategorization({ onNext }: { onNext: () => void }) {
 
       <div className="grid grid-cols-2 gap-4 w-full mt-8">
         <OnboardingButton
-          label="Skip for now"
+          label="Back"
           variant="plain"
-          onClick={onNext}
+          onClick={onBack}
           disabled={isSaving}
         />
         <OnboardingButton
@@ -67,6 +67,14 @@ export function CorporateCategorization({ onNext }: { onNext: () => void }) {
           loading={isSaving}
         />
       </div>
+      <button
+        type="button"
+        className="mt-3 text-sm text-[#858585] hover:text-[#042E27] hover:underline"
+        disabled={isSaving}
+        onClick={onNext}
+      >
+        Skip for now
+      </button>
     </section>
   );
 }

--- a/src/components/onboarding/organisms/fundraiser/UploadBusinessDocument.tsx
+++ b/src/components/onboarding/organisms/fundraiser/UploadBusinessDocument.tsx
@@ -93,9 +93,9 @@ const OFFERING_FIELDS: readonly OfferingField[] = [
 const getBusinessSizeInfo = (size: string | undefined) => {
     switch (size) {
         case 'Micro':
-            return 'Choosing the "micro" option will restrict the maximum annual cap to ₦50 million.';
-        case 'Small':
             return 'Please specify the funding target within the permitted range: ₦25,000,000 and not more than ₦100,000,000.';
+        case 'Small':
+            return 'Choosing the "small" option will restrict the maximum annual cap to ₦50 million.';
         case 'Medium':
             return 'Choosing the "medium" option restrict the maximum annual cap to ₦100 million.';
         default:
@@ -106,15 +106,18 @@ const getBusinessSizeInfo = (size: string | undefined) => {
 const getFundingError = (amount: string | undefined, size: string | undefined): string | null => {
     if (!amount) return "Required";
     const val = Number(amount);
+    if (!Number.isFinite(val) || val <= 0) {
+        return "Please enter a valid funding amount";
+    }
 
     switch (size) {
         case 'Micro':
-            return val > 50000000 ? "Please input a different amount less than or equal to ₦50 million" : null;
-        case 'Small':
             if (val < 25000000 || val > 100000000) {
                 return "Please specify the funding target within the permitted range: ₦25,000,000 to ₦100,000,000";
             }
             return null;
+        case 'Small':
+            return val > 50000000 ? "Please input a different amount less than or equal to ₦50 million" : null;
         case 'Medium':
             return val > 100000000 ? "Please input a different amount less than or equal to ₦100 million" : null;
         default:
@@ -129,6 +132,7 @@ interface UploadBusinessDocumentProps {
     customSubmitAction?: (data: AddNewInvestmentFormPayload) => Promise<void>;
     onSuccessCallback?: () => void;
     onCancelCallback?: () => void;
+    onBack?: () => void;
 }
 
 export function UploadBusinessDocument({
@@ -138,6 +142,7 @@ export function UploadBusinessDocument({
     customSubmitAction,
     onSuccessCallback,
     onCancelCallback,
+    onBack,
 }: UploadBusinessDocumentProps) {
     const router = useRouter();
     const { saveBusinessDocuments } = useFundraiserOnboardingApi();
@@ -166,7 +171,6 @@ export function UploadBusinessDocument({
 
     const handleFieldUpdate = (field: keyof AddNewInvestmentFormPayload, value: string | File | null) => {
         activeUpdateFormData({ [field]: value });
-        if (showErrors) setShowErrors(false);
     };
 
     const businessSizeInfo = useMemo(() =>
@@ -221,6 +225,8 @@ export function UploadBusinessDocument({
     const handleBack = () => {
         if (onCancelCallback) {
             onCancelCallback();
+        } else if (onBack) {
+            onBack();
         } else {
             router.back();
         }
@@ -252,6 +258,7 @@ export function UploadBusinessDocument({
                             onUpload={(file) => handleFieldUpdate(section.field, file)}
                             value={fieldValue ?? null}
                             isError={section.required && showErrors && !fieldValue}
+                            documentsOnly
                         />
                     );
                 })}
@@ -299,7 +306,12 @@ export function UploadBusinessDocument({
 
                                         {(() => {
                                             const fundingError = getFundingError(activeFormData.fundingTarget, activeFormData.businessSize);
-                                            const isTargetError = showErrors && fundingError;
+                                            const hasAmount = Boolean(activeFormData.fundingTarget);
+                                            const rangeError = fundingError && fundingError !== "Required" ? fundingError : null;
+                                            const displayError = showErrors
+                                                ? fundingError
+                                                : (hasAmount ? rangeError : null);
+                                            const isTargetError = Boolean(displayError);
 
                                             return (
                                                 <>
@@ -326,7 +338,7 @@ export function UploadBusinessDocument({
                                                         />
                                                     </div>
                                                     {isTargetError && (
-                                                        <span className="text-xs text-red-500 mt-1">{fundingError}</span>
+                                                        <span className="text-xs text-red-500 mt-1">{displayError}</span>
                                                     )}
                                                 </>
                                             );

--- a/src/components/onboarding/organisms/individual/investor-step/InvestorStep.tsx
+++ b/src/components/onboarding/organisms/individual/investor-step/InvestorStep.tsx
@@ -10,7 +10,7 @@ import onboardingService from '@/services/onboardingService';
 import { mapToInvestmentProfilePayload } from '@/lib/onboarding-payload-mappers';
 import { showApiErrorToast } from '@/lib/error-feedback';
 
-export function InvestorStep({ onNext }: { onNext: () => void }) {
+export function InvestorStep({ onNext, onBack }: { onNext: () => void; onBack: () => void }) {
     const { formData } = useOnboardingStore();
     const [view, setView] = useState<"selection" | "questionnaire">(
         formData.selectedCategoryId ? "questionnaire" : "selection"
@@ -108,11 +108,11 @@ export function InvestorStep({ onNext }: { onNext: () => void }) {
 
             <div className="grid grid-cols-2 gap-4 w-full mt-8">
                 <OnboardingButton
-                    label={view === "selection" ? "Skip for now" : "Go Back"}
+                    label={view === "selection" ? "Back" : "Go Back"}
                     variant="plain"
                     disabled={isSavingCategory || isSavingProfile}
                     onClick={() => {
-                        if (view === "selection") onNext();
+                        if (view === "selection") onBack();
                         else {
                             setView("selection");
                             setShowErrors(false);
@@ -126,6 +126,16 @@ export function InvestorStep({ onNext }: { onNext: () => void }) {
                     loading={isSavingCategory || isSavingProfile}
                 />
             </div>
+            {view === "selection" && (
+                <button
+                    type="button"
+                    className="mt-3 text-sm text-[#858585] hover:text-[#042E27] hover:underline"
+                    disabled={isSavingCategory || isSavingProfile}
+                    onClick={onNext}
+                >
+                    Skip for now
+                </button>
+            )}
         </section>
     );
 }

--- a/src/components/onboarding/organisms/individual/personal-step/PersonalStep.tsx
+++ b/src/components/onboarding/organisms/individual/personal-step/PersonalStep.tsx
@@ -12,9 +12,17 @@ import { PersonalSubStepId, validatePersonalStep } from '@/lib/onboardingValidat
 import authService from '@/services/authService';
 import { tokenStorage } from '@/lib/token-storage';
 import { showApiErrorToast } from '@/lib/error-feedback';
+import { useUserStore } from '@/store/userStore';
+import { mapApiUserTypeToStoreUserType } from '@/lib/user-type';
 
 export function PersonalStep() {
-    const { personalSubStep: subStep, setPersonalSubStep: setSubStep, formData, setEmailVerified } = useOnboardingStore();
+    const {
+        personalSubStep: subStep,
+        setPersonalSubStep: setSubStep,
+        formData,
+        setEmailVerified,
+        emailVerified,
+    } = useOnboardingStore();
     const [showErrors, setShowErrors] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -30,6 +38,13 @@ export function PersonalStep() {
 
     const canProceed = validatePersonalStep(currentStep.id as PersonalSubStepId, formData);
 
+    const backSubstep = () => {
+        if (subStep > 0) {
+            setShowErrors(false);
+            setSubStep(subStep - 1);
+        }
+    };
+
     const handleNext = async () => {
         if (!canProceed) {
             setShowErrors(true);
@@ -38,6 +53,12 @@ export function PersonalStep() {
 
         setShowErrors(false);
         if (isLastSubStep) {
+            // Account already exists after email verification — keep edits and resume flow.
+            if (emailVerified) {
+                router.push('/onboarding/individual/investor');
+                return;
+            }
+
             setIsSubmitting(true);
 
             try {
@@ -63,6 +84,14 @@ export function PersonalStep() {
                     tokenStorage.setRefreshToken(data.refreshToken);
                 }
                 setEmailVerified(data.isEmailVerified);
+                useUserStore.getState().setUserId(String(data.userId));
+                useUserStore.getState().updateProfile({
+                    emailAddress: data.email,
+                    firstName: formData.firstName,
+                    lastName: formData.lastName,
+                    userType: mapApiUserTypeToStoreUserType(data.userType),
+                    isEmailVerified: data.isEmailVerified,
+                });
 
                 router.push('/onboarding/individual/email');
             } catch (error) {
@@ -74,6 +103,12 @@ export function PersonalStep() {
             setSubStep(subStep + 1);
         }
     };
+
+    const primaryLabel = subStep === 0
+        ? "Proceed"
+        : emailVerified
+            ? (isSubmitting ? "Saving…" : "Save & Continue")
+            : (isSubmitting ? "Creating account…" : "Create Account");
 
     return (
         <div className="w-full lg:w-[558px] flex flex-col gap-4">
@@ -91,18 +126,23 @@ export function PersonalStep() {
                 {currentStep && stepContent[currentStep.id]}
             </div>
 
-            <OnboardingButton
-                label={
-                    subStep === 0
-                        ? "Proceed"
-                        : isSubmitting
-                          ? "Creating account…"
-                          : "Create Account"
-                }
-                variant="solid"
-                onClick={handleNext}
-                loading={isSubmitting}
-            />
+            <div className={`flex items-center pt-8 pb-10 ${subStep > 0 ? "justify-between" : ""}`}>
+                {subStep > 0 && (
+                    <OnboardingButton
+                        label="Back"
+                        variant="plain"
+                        onClick={backSubstep}
+                        className="w-[115px]"
+                    />
+                )}
+                <OnboardingButton
+                    label={primaryLabel}
+                    variant="solid"
+                    onClick={handleNext}
+                    loading={isSubmitting}
+                    className={subStep > 0 ? "w-[230px]" : undefined}
+                />
+            </div>
         </div>
     )
 }

--- a/src/components/onboarding/organisms/onboarding-sidebar/OnboardingSidebar.tsx
+++ b/src/components/onboarding/organisms/onboarding-sidebar/OnboardingSidebar.tsx
@@ -8,10 +8,15 @@ import { ONBOARDING_CONFIG, InvestorUserType, StepKey, isKnownOnboardingStep, On
 import { AllowedStepBeforeVerify, useOnboardingStore } from "@/store/onboardingStore"
 import { SubSteps } from "@/components/onboarding/organisms/onboarding-sidebar/subSteps"
 import { toast } from "sonner"
+import { LogOut } from "lucide-react"
+import useLogout from "@/hooks/use-logout"
+
+const HIGHEST_STEP_KEY = "onboarding_highestStepIndex"
 
 export default function OnboardingSidebar() {
     const router = useRouter()
     const pathname = usePathname()
+    const logoutMutation = useLogout()
 
 
     const {
@@ -58,16 +63,31 @@ export default function OnboardingSidebar() {
         setLastAllowedStep
     ]);
 
-    const hasMovedPastVerificationGate =
-        emailVerified && !ALLOWED_STEP_BEFORE_VERIFICATION.includes(currentStep);
-
     const isInReviewLockPhase = ["review", "activation", "application-submitted"].includes(currentStep);
 
     const currentStepIndex = steps.findIndex(s => s.key === currentStep);
 
+    // Keep the farthest step reached so users can edit earlier steps (e.g. personal)
+    // after email verify without locking later steps in the sidebar.
+    const [highestStepIndex, setHighestStepIndex] = React.useState(currentStepIndex);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const stored = Number(sessionStorage.getItem(HIGHEST_STEP_KEY) ?? "-1");
+        const fromStorage = Number.isFinite(stored) ? stored : -1;
+        const next = Math.max(currentStepIndex, fromStorage, highestStepIndex);
+        if (next !== highestStepIndex) {
+            setHighestStepIndex(next);
+        }
+        if (currentStepIndex >= 0 && currentStepIndex > fromStorage) {
+            sessionStorage.setItem(HIGHEST_STEP_KEY, String(currentStepIndex));
+        }
+    }, [currentStepIndex, highestStepIndex]);
+
     const isMenuLockedStep = (stepKey: StepKey): boolean => {
-        if (hasMovedPastVerificationGate && ALLOWED_STEP_BEFORE_VERIFICATION.includes(stepKey)) {
-            return true;
+        // After email verify, personal/company/email stay editable from the menu.
+        if (emailVerified && ALLOWED_STEP_BEFORE_VERIFICATION.includes(stepKey)) {
+            return false;
         }
 
         // Once user reaches review/final stage, keep navigation on the current stage.
@@ -77,7 +97,7 @@ export default function OnboardingSidebar() {
 
         // Prevent navigating to future steps that haven't been reached yet.
         const stepIndex = steps.findIndex(s => s.key === stepKey);
-        if (stepIndex > currentStepIndex) {
+        if (stepIndex > highestStepIndex) {
             return true;
         }
 
@@ -89,10 +109,8 @@ export default function OnboardingSidebar() {
         if (isMenuLockedStep(stepKey)) {
             if (isInReviewLockPhase) {
                 toast.info("Navigation is locked at application review stage.");
-            } else if (stepIndex > currentStepIndex) {
+            } else if (stepIndex > highestStepIndex) {
                 toast.info("Please complete the current step before proceeding.");
-            } else {
-                toast.info("This step is locked after verification.");
             }
             return;
         }
@@ -194,6 +212,15 @@ export default function OnboardingSidebar() {
                 <p className="text-[#545C19] leading-tight text-[12px] w-[279px] pt-[24px] opacity-80 font-[family-name:var(--font-dm-sans)]">
                     Tip: Your information helps us verify your account and keep things secure
                 </p>
+                <button
+                    type="button"
+                    onClick={() => logoutMutation.mutate()}
+                    disabled={logoutMutation.isPending}
+                    className="mt-6 flex items-center gap-2 text-[14px] text-[#042E27] hover:underline disabled:opacity-60 font-[family-name:var(--font-dm-sans)] cursor-pointer"
+                >
+                    <LogOut className="h-4 w-4" />
+                    {logoutMutation.isPending ? "Logging out…" : "Log out"}
+                </button>
             </div>
         </nav>
     )

--- a/src/hooks/use-login.ts
+++ b/src/hooks/use-login.ts
@@ -9,6 +9,7 @@ import { showApiErrorToast } from "@/lib/error-feedback";
 import { resolvePostLoginPath } from "@/lib/post-login-navigation";
 import { mapApiUserTypeToStoreUserType } from "@/lib/user-type";
 import { useUserStore } from "@/store/userStore";
+import { useOnboardingStore } from "@/store/onboardingStore";
 
 export type { LoginRequest, LoginResponse };
 
@@ -33,7 +34,12 @@ const useLogin = (options?: UseLoginOptions) => {
       useUserStore.getState().updateProfile({
         emailAddress: data.email,
         userType: mapApiUserTypeToStoreUserType(data.userType),
+        isEmailVerified: data.isEmailVerified,
       });
+      useOnboardingStore.getState().setEmailVerified(data.isEmailVerified);
+      useOnboardingStore.getState().setInvestorUserType(
+        mapApiUserTypeToStoreUserType(data.userType)
+      );
 
       queryClient.invalidateQueries({ queryKey: CACHE_KEY_USER });
 

--- a/src/hooks/use-logout.ts
+++ b/src/hooks/use-logout.ts
@@ -7,6 +7,18 @@ import { CACHE_KEY_USER } from "@/constants";
 import { tokenStorage } from "@/lib/token-storage";
 import { showApiErrorToast } from "@/lib/error-feedback";
 import { useUserStore } from "@/store/userStore";
+import { useOnboardingStore } from "@/store/onboardingStore";
+
+function clearLocalSession(queryClient: ReturnType<typeof useQueryClient>) {
+  tokenStorage.clear();
+  useUserStore.getState().clearUser();
+  useOnboardingStore.getState().resetOnboarding();
+  if (typeof window !== "undefined") {
+    sessionStorage.removeItem("onboarding_lastAllowedStep");
+    sessionStorage.removeItem("onboarding_highestStepIndex");
+  }
+  queryClient.invalidateQueries({ queryKey: CACHE_KEY_USER });
+}
 
 const useLogout = () => {
   const router = useRouter();
@@ -16,13 +28,14 @@ const useLogout = () => {
     mutationKey: ["logout"],
     mutationFn: authService.logout,
     onSuccess: () => {
-      tokenStorage.clear();
-      useUserStore.getState().clearUser();
-      queryClient.invalidateQueries({ queryKey: CACHE_KEY_USER });
+      clearLocalSession(queryClient);
       router.push("/sign-in");
     },
     onError: (err) => {
+      // Still end the local session if the API call fails.
+      clearLocalSession(queryClient);
       showApiErrorToast(err, "Unable to logout.");
+      router.push("/sign-in");
     },
   });
 };

--- a/src/lib/onboarding-hydration.ts
+++ b/src/lib/onboarding-hydration.ts
@@ -11,6 +11,7 @@ import type {
   ApiOnboardingStep,
   OnboardingResponse,
 } from "@/types/onboarding";
+import type { UserProfile } from "@/types/user-api";
 
 const INVESTOR_CATEGORY_TO_UI: Record<string, OnboardingFormData["selectedCategoryId"]> =
   {
@@ -342,6 +343,60 @@ export function buildFormPatchFromOnboarding(
   }
   if (incomeTypes.length > 0) kycPatch.incomeDocuments = incomeTypes;
   if (Object.keys(kycPatch).length > 0) patch.kycData = kycPatch;
+
+  return patch;
+}
+
+/** Hydrate signup/personal (and company) fields from GET /api/users/{id} — used before email verify. */
+export function buildFormPatchFromUserProfile(
+  profile: UserProfile
+): Parameters<OnboardingState["updateFormData"]>[0] {
+  const patch: Parameters<OnboardingState["updateFormData"]>[0] = {};
+
+  if (profile.firstName) patch.firstName = profile.firstName;
+  if (profile.lastName) patch.lastName = profile.lastName;
+  if (profile.email) patch.email = profile.email;
+  if (profile.preferredName) patch.alias = profile.preferredName;
+  if (profile.phoneNumber) patch.phone = profile.phoneNumber;
+  if (profile.dateOfBirth) patch.dob = String(profile.dateOfBirth).slice(0, 10);
+  if (profile.nationality) patch.nationality = profile.nationality;
+  if (profile.countryOfResidence) patch.residence = profile.countryOfResidence;
+  if (profile.stateOfResidence) patch.state = profile.stateOfResidence;
+  if (profile.residentialAddress) patch.address = profile.residentialAddress;
+  if (profile.hasAgreedToTerms === true) patch.agreed = true;
+
+  const company = profile.company;
+  if (company) {
+    if (company.companyLegalName) patch.companyName = company.companyLegalName;
+    if (company.tradingBrandName) patch.brandName = company.tradingBrandName;
+    if (company.registrationType) patch.registrationType = company.registrationType;
+    if (company.registrationNumber) patch.registrationNumber = company.registrationNumber;
+    if (company.companyLoginEmail) patch.loginEmail = company.companyLoginEmail;
+    else if (profile.email) patch.loginEmail = profile.email;
+    if (company.dateOfRegistration) {
+      patch.registrationDate = String(company.dateOfRegistration).slice(0, 10);
+    }
+    if (company.companyWebsite) patch.companyWebsite = company.companyWebsite;
+    if (company.businessAddress) patch.businessAddress = company.businessAddress;
+    if (company.registeredAddress) patch.registeredAddress = company.registeredAddress;
+    if (company.companyEmail) patch.companyEmail = company.companyEmail;
+    if (company.companyPhone) patch.companyPhone = company.companyPhone;
+    if (company.representativeFullName) patch.repFullName = company.representativeFullName;
+    if (company.representativeJobTitle) patch.repJobTitle = company.representativeJobTitle;
+    if (company.representativePhoneNumber) patch.repPhoneNumber = company.representativePhoneNumber;
+    if (company.representativeDateOfBirth) {
+      patch.repDob = String(company.representativeDateOfBirth).slice(0, 10);
+    }
+    if (company.representativeEmail) patch.repEmail = company.representativeEmail;
+    if (company.representativeNationality) patch.repNationality = company.representativeNationality;
+    if (company.representativeCountryOfResidence) {
+      patch.repResidence = company.representativeCountryOfResidence;
+    }
+    if (company.representativeAddress) patch.repAddress = company.representativeAddress;
+  } else if (profile.email) {
+    // Corporate login email often mirrors user email at signup.
+    patch.loginEmail = profile.email;
+  }
 
   return patch;
 }

--- a/src/lib/post-login-navigation.ts
+++ b/src/lib/post-login-navigation.ts
@@ -19,7 +19,7 @@ function firstStepKeyForType(type: InvestorUserType): string {
   return ONBOARDING_CONFIG[type][0].key;
 }
 
-function isOnboardingCompleteStatus(status: OnboardingResponse["status"]): boolean {
+export function isOnboardingCompleteStatus(status: OnboardingResponse["status"]): boolean {
   if (status === undefined || status === null) return false;
   const s = String(status).toLowerCase().replace(/\s/g, "");
   return (
@@ -36,6 +36,49 @@ export interface PostLoginNavigationOptions {
   fromTrading?: boolean;
 }
 
+export type SessionResumeKind = "email" | "onboarding" | "dashboard" | "checkout";
+
+export interface SessionResume {
+  path: string;
+  kind: SessionResumeKind;
+}
+
+/**
+ * Same destination rules as post-login: email verify → resume onboarding → dashboard.
+ * Safe to call from marketing chrome when a session token already exists.
+ */
+export async function resolveSessionResumePath(input: {
+  userType: string;
+  isEmailVerified: boolean;
+  fromTrading?: boolean;
+}): Promise<SessionResume> {
+  const type = mapLoginUserTypeToInvestorPathSegment(input.userType);
+  const pendingInvestment = readPendingInvestment();
+
+  if (!input.isEmailVerified) {
+    return { path: `/onboarding/${type}/email`, kind: "email" };
+  }
+
+  try {
+    const onboarding = await onboardingService.getOnboarding();
+    if (isOnboardingCompleteStatus(onboarding.status)) {
+      if (input.fromTrading && pendingInvestment) {
+        const checkoutPath = buildCheckoutPath(pendingInvestment);
+        clearPendingInvestment();
+        return { path: checkoutPath, kind: "checkout" };
+      }
+      return { path: "/dashboard", kind: "dashboard" };
+    }
+    const stepKey = mapOnboardingStepToUiStep(onboarding.currentStep, type);
+    return { path: `/onboarding/${type}/${stepKey}`, kind: "onboarding" };
+  } catch {
+    return {
+      path: `/onboarding/${type}/${firstStepKeyForType(type)}`,
+      kind: "onboarding",
+    };
+  }
+}
+
 /**
  * Where to send the user immediately after a successful login (tokens not yet required for this function;
  * callers must persist tokens before calling `getOnboarding` inside here).
@@ -44,26 +87,10 @@ export async function resolvePostLoginPath(
   login: LoginResponse,
   options?: PostLoginNavigationOptions
 ): Promise<string> {
-  const type = mapLoginUserTypeToInvestorPathSegment(login.userType);
-  const pendingInvestment = readPendingInvestment();
-
-  if (!login.isEmailVerified) {
-    return `/onboarding/${type}/email`;
-  }
-
-  try {
-    const onboarding = await onboardingService.getOnboarding();
-    if (isOnboardingCompleteStatus(onboarding.status)) {
-      if (options?.fromTrading && pendingInvestment) {
-        const checkoutPath = buildCheckoutPath(pendingInvestment);
-        clearPendingInvestment();
-        return checkoutPath;
-      }
-      return "/dashboard";
-    }
-    const stepKey = mapOnboardingStepToUiStep(onboarding.currentStep, type);
-    return `/onboarding/${type}/${stepKey}`;
-  } catch {
-    return `/onboarding/${type}/${firstStepKeyForType(type)}`;
-  }
+  const resume = await resolveSessionResumePath({
+    userType: login.userType,
+    isEmailVerified: login.isEmailVerified,
+    fromTrading: options?.fromTrading,
+  });
+  return resume.path;
 }

--- a/src/store/onboardingStore.ts
+++ b/src/store/onboardingStore.ts
@@ -113,6 +113,7 @@ export interface OnboardingState {
     setEmailVerified: (verified: boolean) => void
     setLastAllowedStep: (step: AllowedStepBeforeVerify) => void
     updateFormData: (data: Partial<Omit<OnboardingFormData, 'kycData'>> & { kycData?: Partial<KYCData> }) => void
+    resetOnboarding: () => void
 }
 
 const initialFormData: OnboardingFormData = {
@@ -226,5 +227,18 @@ export const useOnboardingStore = create<OnboardingState>((set) => ({
                     kycData: updatedKycData
                 }
             };
+        }),
+
+    resetOnboarding: () =>
+        set({
+            investorUserType: null,
+            currentStep: "personal",
+            personalSubStep: 0,
+            companySubStep: 0,
+            fundraiserCompanySubStep: 0,
+            kycSubStep: 0,
+            emailVerified: false,
+            lastAllowedStep: "personal",
+            formData: initialFormData,
         }),
 }))

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -14,6 +14,7 @@ export interface UserData {
     profilePictureUrl: string | null
     userType: UserType
     isKycCompleted: boolean
+    isEmailVerified: boolean
 }
 
 interface UserState extends UserData {
@@ -36,6 +37,7 @@ export const useUserStore = create<UserState>()(
             profilePictureUrl: null,
             userType: "individual",
             isKycCompleted: false,
+            isEmailVerified: false,
 
             setUserId: (id) => set(() => ({ userId: id })),
 
@@ -52,6 +54,7 @@ export const useUserStore = create<UserState>()(
                 profilePictureUrl: null,
                 userType: "individual",
                 isKycCompleted: false,
+                isEmailVerified: false,
             })),
         }),
         {

--- a/src/types/user-api.ts
+++ b/src/types/user-api.ts
@@ -1,3 +1,25 @@
+export interface UserCompanyProfile {
+  companyLegalName?: string | null;
+  tradingBrandName?: string | null;
+  registrationType?: string | null;
+  registrationNumber?: string | null;
+  companyLoginEmail?: string | null;
+  dateOfRegistration?: string | null;
+  companyWebsite?: string | null;
+  businessAddress?: string | null;
+  registeredAddress?: string | null;
+  companyEmail?: string | null;
+  companyPhone?: string | null;
+  representativeFullName?: string | null;
+  representativeJobTitle?: string | null;
+  representativePhoneNumber?: string | null;
+  representativeDateOfBirth?: string | null;
+  representativeEmail?: string | null;
+  representativeNationality?: string | null;
+  representativeCountryOfResidence?: string | null;
+  representativeAddress?: string | null;
+}
+
 export interface UserProfile {
   id: number;
   email: string;
@@ -7,4 +29,11 @@ export interface UserProfile {
   preferredName?: string | null;
   userType: string;
   isEmailVerified: boolean;
+  dateOfBirth?: string | null;
+  nationality?: string | null;
+  countryOfResidence?: string | null;
+  stateOfResidence?: string | null;
+  residentialAddress?: string | null;
+  hasAgreedToTerms?: boolean;
+  company?: UserCompanyProfile | null;
 }


### PR DESCRIPTION
## Summary
- Landing navbar treats users as logged in only after email verification; mid-onboarding users get **Continue Onboarding** (same resume logic as login) instead of Dashboard.
- Onboarding: Back + Create Account on personal/company steps, editable pre-email steps after verify, sidebar/mobile logout, and personal details refilled from the user API after logout/login.
- Sidebar Log Out runs the real logout flow (no `/log-out` 404); email verify resend/OTP falls back to user store/API for missing form email.

## Test plan
- [x] Unverified signup → landing shows Invest/Raise (not avatar/Dashboard)
- [x] Verified but incomplete onboarding → landing shows Continue Onboarding and resumes correct step
- [x] Personal location step: Back + Create Account; first step has full-width Proceed only
- [x] After email verify, sidebar allows editing personal/company without re-verify
- [x] Logout from onboarding sidebar (desktop) and mobile; login again → personal fields populated
- [x] Sidebar Log Out from dashboard goes to sign-in (no 404)
- [x] Resend verification / delete OTP works after refresh without empty-email toast


Made with [Cursor](https://cursor.com)