### PR TITLE
Wire fundraiser dashboard to API

### DIFF
--- a/src/app/(dashboard)/dashboard/Dashboard.tsx
+++ b/src/app/(dashboard)/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { DataTable } from "@/app/(dashboard)/dashboard/components/data-table"
 import { SectionCards } from "@/app/(dashboard)/dashboard/components/section-cards"
 import { useCurrentUser } from "@/hooks/use-current-user"
 import { useDashboard } from "@/hooks/use-dashboard"
+import { useFundraiserDashboard } from "@/hooks/use-fundraiser-dashboard"
 import { buildDashboardMonthOptions, toDashboardPeriod } from "@/lib/dashboard-period"
 import { showApiErrorToast } from "@/lib/error-feedback"
 import { resolveUserDisplayName } from "@/lib/user-display-name"
@@ -15,20 +16,43 @@ import { FundingProgress } from "@/app/(dashboard)/dashboard/components/funding-
 import { InvestorBreakdownChart } from "@/app/(dashboard)/dashboard/components/investor-breakdown-chart"
 import { FundraisingMilestones } from "@/app/(dashboard)/dashboard/components/fundraising-milestones"
 
+function formatVelocityLabel(amount: number, period: string): string {
+    const safeAmount = Number.isFinite(amount) ? Math.max(0, amount) : 0
+    const formatted = safeAmount <= 0
+        ? "₦0"
+        : `₦${(safeAmount / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`
+    const periodLabel = period === "week" ? "Week" : period
+    return `${formatted} / ${periodLabel}`
+}
+
 export function Dashboard() {
     const months = useMemo(() => buildDashboardMonthOptions(), [])
     const [selectedMonth, setSelectedMonth] = useState("This month")
     const period = toDashboardPeriod(selectedMonth)
     const { data: user, isError: isUserError, error: userError } = useCurrentUser()
-    const { data, isLoading, isError, error } = useDashboard(period)
 
-    // Select the userType from your Zustand store
     const userType = useUserStore((state) => state.userType)
     const [hasHydrated, setHasHydrated] = useState(false)
 
     useEffect(() => {
         setHasHydrated(true)
     }, [])
+
+    const isFundraiser = hasHydrated && userType === "fundraiser"
+
+    const {
+        data: investorData,
+        isLoading: isInvestorLoading,
+        isError: isInvestorError,
+        error: investorError,
+    } = useDashboard(period, hasHydrated && !isFundraiser)
+
+    const {
+        data: fundraiserData,
+        isLoading: isFundraiserLoading,
+        isError: isFundraiserError,
+        error: fundraiserError,
+    } = useFundraiserDashboard(period, isFundraiser)
 
     useEffect(() => {
         if (isUserError) {
@@ -37,21 +61,27 @@ export function Dashboard() {
     }, [isUserError, userError])
 
     useEffect(() => {
-        if (isError) {
-            showApiErrorToast(error, "Unable to load dashboard.")
+        if (!isFundraiser && isInvestorError) {
+            showApiErrorToast(investorError, "Unable to load dashboard.")
         }
-    }, [isError, error])
+    }, [isFundraiser, isInvestorError, investorError])
+
+    useEffect(() => {
+        if (isFundraiser && isFundraiserError) {
+            showApiErrorToast(fundraiserError, "Unable to load fundraiser dashboard.")
+        }
+    }, [isFundraiser, isFundraiserError, fundraiserError])
 
     const displayName = resolveUserDisplayName(user)
-
     const currentUserType = hasHydrated ? userType : "individual"
+    const isLoading = isFundraiser ? isFundraiserLoading : isInvestorLoading
 
     return (
         <main>
             <DashboardSubHeader
                 title={`Welcome back, ${displayName}`}
                 desc={
-                    hasHydrated && userType === "fundraiser"
+                    isFundraiser
                         ? "Here is a real-time summary of your current fundraising campaign."
                         : "Here is a summary of overall data"
                 }
@@ -59,42 +89,60 @@ export function Dashboard() {
                 months={months}
                 onMonthChange={setSelectedMonth}
                 userType={currentUserType}
+                hasActiveFundraising={Boolean(fundraiserData?.offeringId)}
             />
 
             <div className="@container/main space-y-6">
                 <SectionCards
-                    summary={data?.summary}
+                    summary={investorData?.summary}
+                    fundraiserSummary={fundraiserData?.summary}
                     isLoading={isLoading}
                     userType={currentUserType}
                 />
-                {userType !== "fundraiser" ?
+                {!isFundraiser ? (
                     <PortfolioStatChart
-                        portfolioPerformance={data?.portfolioPerformance}
-                        activeDeals={data?.activeDeals}
-                        holdings={data?.holdings}
+                        portfolioPerformance={investorData?.portfolioPerformance}
+                        activeDeals={investorData?.activeDeals}
+                        holdings={investorData?.holdings}
                         isLoading={isLoading}
                     />
-                    : <div className="grid grid-cols-1 xl:grid-cols-10 mb-12 gap-5">
+                ) : (
+                    <div className="grid grid-cols-1 xl:grid-cols-10 mb-12 gap-5">
                         <div className="xl:col-span-7">
-                            <FundingProgress />
+                            <FundingProgress
+                                raisedAmount={fundraiserData?.fundingProgress.raisedAmount ?? 0}
+                                targetAmount={fundraiserData?.fundingProgress.targetAmount ?? 0}
+                                minimumThreshold={fundraiserData?.fundingProgress.minimumThreshold ?? 0}
+                                currentVelocity={formatVelocityLabel(
+                                    fundraiserData?.fundingProgress.currentVelocity ?? 0,
+                                    fundraiserData?.fundingProgress.velocityPeriod ?? "week"
+                                )}
+                                confidenceRate={fundraiserData?.fundingProgress.confidenceRate ?? 0}
+                                isLoading={isLoading}
+                            />
                         </div>
                         <div className="xl:col-span-3">
-                            <InvestorBreakdownChart />
+                            <InvestorBreakdownChart
+                                buckets={fundraiserData?.investorBreakdown.buckets}
+                                isLoading={isLoading}
+                            />
                         </div>
                     </div>
-                }
+                )}
             </div>
 
-
-            {userType !== "fundraiser" ?
+            {!isFundraiser ? (
                 <DataTable
-                    holdings={data?.holdings}
+                    holdings={investorData?.holdings}
                     isLoading={isLoading}
                     userType={currentUserType}
                 />
-                : <FundraisingMilestones />
-
-            }
+            ) : (
+                <FundraisingMilestones
+                    milestones={fundraiserData?.milestones}
+                    isLoading={isLoading}
+                />
+            )}
         </main>
     )
 }

--- a/src/app/(dashboard)/dashboard/components/funding-progress.tsx
+++ b/src/app/(dashboard)/dashboard/components/funding-progress.tsx
@@ -6,40 +6,38 @@ import { cn } from "@/lib/utils"
 import { TYPOGRAPHY } from "@/constants/styles"
 
 interface FundingProgressProps {
-    raisedAmount?: number // e.g., 142500000
-    targetAmount?: number // e.g., 200000000
-    minimumThreshold?: number // e.g., 100000000
-    currentVelocity?: string // e.g., "₦8.5M / Week"
-    confidenceRate?: number // e.g., 88
+    raisedAmount?: number
+    targetAmount?: number
+    minimumThreshold?: number
+    currentVelocity?: string
+    confidenceRate?: number
     isLoading?: boolean
 }
 
 export function FundingProgress({
-    raisedAmount = 142500000,
-    targetAmount = 200000000,
-    minimumThreshold = 100000000,
-    currentVelocity = "₦8.5M / Week",
-    confidenceRate = 88,
+    raisedAmount = 0,
+    targetAmount = 0,
+    minimumThreshold = 0,
+    currentVelocity = "₦0 / Week",
+    confidenceRate = 0,
     isLoading = false,
 }: FundingProgressProps) {
+    const safeTarget = targetAmount > 0 ? targetAmount : 1
+    const safeThreshold = minimumThreshold > 0 ? minimumThreshold : 1
+    const percentageOfTarget = Math.min((raisedAmount / safeTarget) * 100, 100)
+    const isThresholdReached = minimumThreshold > 0 && raisedAmount >= minimumThreshold
 
-    // Calculate Progress Percentages
-    const percentageOfTarget = Math.min((raisedAmount / targetAmount) * 100, 100)
-    const isThresholdReached = raisedAmount >= minimumThreshold
-
-    // SVG Donut Chart Configurations
     const radius = 65
     const circumference = 2 * Math.PI * radius
     const strokeDashoffset = circumference - (percentageOfTarget / 100) * circumference
 
-    // Utility to format values like 142500000 -> ₦142.5M
     const formatToMillions = (val: number) => {
+        if (val <= 0) return "₦0"
         return `₦${(val / 1000000).toFixed(1).replace(/\.0$/, "")}M`
     }
 
     return (
         <Card className="w-full border-[#EAEAEA] shadow-none rounded-md bg-white overflow-hidden px-6 py-4">
-            {/* Card Header area */}
             <CardHeader className="flex flex-row items-center justify-between p-0 space-y-0">
                 <CardTitle className="text-[16px] text-[#051635]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
                     Funding Progress
@@ -57,13 +55,9 @@ export function FundingProgress({
             </CardHeader>
 
             <CardContent className="p-0">
-                {/* Main Content Layout Grid */}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-8 px-6 pb-10 pt-2 items-center">
-
-                    {/* Left Side: SVG Donut Chart Ring */}
                     <div className="flex justify-center md:justify-start items-center relative w-full max-w-[240px] mx-auto md:mx-0">
                         <svg className="transform rotate-15 w-[214px] h-[214px]" viewBox="0 0 160 160">
-                            {/* Unfilled/Target Track Background Ring */}
                             <circle
                                 cx="80"
                                 cy="80"
@@ -72,7 +66,6 @@ export function FundingProgress({
                                 strokeWidth="23"
                                 fill="transparent"
                             />
-                            {/* Active Raised Capital Filled Ring */}
                             <circle
                                 cx="80"
                                 cy="80"
@@ -87,7 +80,6 @@ export function FundingProgress({
                         </svg>
                     </div>
 
-                    {/* Right Side: Data Breakdowns & Custom Progress Sliders */}
                     <div className="space-y-6 w-full">
                         <div>
                             <h2 className="text-[28px] tracking-tight text-[#1B1B1B] leading-none" style={TYPOGRAPHY.heading}>
@@ -98,9 +90,7 @@ export function FundingProgress({
                             </p>
                         </div>
 
-                        {/* Custom Milestone Progress Trackers */}
                         <div className="space-y-4">
-                            {/* Minimum Threshold */}
                             <div className="space-y-1.5">
                                 <div className="flex justify-between text-[14px] text-[#505050]" style={TYPOGRAPHY.body} >
                                     <span>Minimum threshold reached</span>
@@ -109,11 +99,10 @@ export function FundingProgress({
                                 <div className="w-full h-2 bg-[#EFF3E4] rounded-full overflow-hidden">
                                     <div
                                         className="h-full bg-[#7D8A26] rounded-full transition-all"
-                                        style={{ width: `${Math.min((raisedAmount / minimumThreshold) * 100, 100)}%` }}
+                                        style={{ width: `${Math.min((raisedAmount / safeThreshold) * 100, 100)}%` }}
                                     />
                                 </div>
 
-                                {/* Condition pill matching active status */}
                                 {isThresholdReached && (
                                     <div className="inline-flex items-center gap-1.5 bg-[#DCE3AD] text-[#7D8A26] px-2.5 py-1 rounded-full text-xs font-semibold mt-1">
                                         <Check className="size-3.5 text-[#7D8A26] stroke-[#7D8A26]" />
@@ -122,7 +111,6 @@ export function FundingProgress({
                                 )}
                             </div>
 
-                            {/* Maximum Cap */}
                             <div className="space-y-1.5">
                                 <div className="flex justify-between text-[14px] text-[#505050]" style={TYPOGRAPHY.body} >
                                     <span>Maximum cap</span>
@@ -139,7 +127,6 @@ export function FundingProgress({
                     </div>
                 </div>
 
-                {/* Bottom Metadata Ribbon Matrix */}
                 <div className="grid grid-cols-1 lg:grid-cols-3 bg-[#F4F5F7] p-3 text-center md:text-left" style={TYPOGRAPHY.body}>
                     <div className="border-b lg:border-b-0 lg:border-r pb-2 lg:pb-0 border-[#A8A8A8]">
                         <p className="text-[14px] text-[#858585] tracking-wider">Minimum threshold</p>

--- a/src/app/(dashboard)/dashboard/components/fundraising-milestones.tsx
+++ b/src/app/(dashboard)/dashboard/components/fundraising-milestones.tsx
@@ -4,54 +4,19 @@ import { Check } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import { TYPOGRAPHY } from "@/constants/styles"
+import type { FundraiserMilestone, FundraiserMilestoneStatus } from "@/types/fundraiser-dashboard-api"
 
-type MilestoneStatus = "completed" | "active" | "pending"
-
-interface MilestoneItem {
-    title: string
-    description: string
-    dateLabel: string
-    status: MilestoneStatus
+interface FundraisingMilestonesProps {
+    milestones?: FundraiserMilestone[]
+    isLoading?: boolean
 }
 
-export function FundraisingMilestones() {
-    // Mock timeline steps exactly matching the content configuration of image_6300ba.png
-    const milestones: MilestoneItem[] = [
-        {
-            title: "Launch",
-            description: "Name and email",
-            dateLabel: "Jan 15, 2025",
-            status: "completed",
-        },
-        {
-            title: "25% Funded",
-            description: "Website and location",
-            dateLabel: "Target: Mar 18",
-            status: "active",
-        },
-        {
-            title: "50% Funded",
-            description: "Start collaborating",
-            dateLabel: "Target: Apr 8",
-            status: "active",
-        },
-        {
-            title: "75% Funded",
-            description: "Automatic sharing",
-            dateLabel: "Target: Jul 23",
-            status: "pending",
-        },
-        {
-            title: "Campaign closed",
-            description: "Automatic sharing",
-            dateLabel: "Target: Sep 1",
-            status: "pending",
-        },
-    ]
-
+export function FundraisingMilestones({
+    milestones = [],
+    isLoading = false,
+}: FundraisingMilestonesProps) {
     return (
         <Card className="w-full border-[#EAEAEA] shadow-none rounded-md bg-white overflow-hidden px-6 py-4">
-            {/* Header Info Area */}
             <CardHeader className="p-0 pb-6 space-y-1">
                 <CardTitle className="text-[16px] text-[#1F1F1F]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
                     Fundraising Milestones
@@ -61,83 +26,82 @@ export function FundraisingMilestones() {
                 </CardDescription>
             </CardHeader>
 
-            <CardContent className="p-0 relative">
-                <div className="flex flex-col w-full relative">
-                    {/* Continuous vertical timeline connector baseline rule */}
-                    <div className="absolute left-[13px] top-4 bottom-4 w-[2px] bg-[#EAEAEA] z-0" />
+            <CardContent className={cn("p-0 relative", isLoading && "animate-pulse opacity-60")}>
+                {milestones.length === 0 ? (
+                    <p className="text-[16px] text-[#858585] py-6">No active fundraising campaign yet.</p>
+                ) : (
+                    <div className="flex flex-col w-full relative">
+                        <div className="absolute left-[13px] top-4 bottom-4 w-[2px] bg-[#EAEAEA] z-0" />
 
-                    {/* Timeline Row Items Map */}
-                    {milestones.map((milestone, idx) => {
-                        const isCompleted = milestone.status === "completed"
-                        const isActive = milestone.status === "active"
-                        const isPending = milestone.status === "pending"
+                        {milestones.map((milestone) => {
+                            const status = milestone.status as FundraiserMilestoneStatus
+                            const isCompleted = status === "completed"
+                            const isActive = status === "active"
+                            const isPending = status === "pending"
 
-                        return (
-                            <div key={idx} className="flex items-start justify-between relative z-10 pb-[56px] pt-0 last:pb-0 group">
+                            return (
+                                <div
+                                    key={milestone.key}
+                                    className="flex items-start justify-between relative z-10 pb-[56px] pt-0 last:pb-0 group"
+                                >
+                                    <div className="flex items-start gap-4 flex-1">
+                                        <div className="flex items-center justify-center mt-0.5 select-none shrink-0">
+                                            {isCompleted && (
+                                                <div className="size-7 rounded-full bg-[#EFF3E4] border border-[#7D9433] flex items-center justify-center">
+                                                    <Check className="size-4 text-[#7D9433] stroke-[3]" />
+                                                </div>
+                                            )}
 
-                                {/* Left Block: Stage Tracking Indicators */}
-                                <div className="flex items-start gap-4 flex-1">
+                                            {isActive && (
+                                                <div className="size-7 rounded-full bg-white border border-[#A2B855] flex items-center justify-center">
+                                                    <div className="size-3 rounded-full bg-[#7D9433]" />
+                                                </div>
+                                            )}
 
-                                    {/* Status Circle Nodes */}
-                                    <div className="flex items-center justify-center mt-0.5 select-none shrink-0">
-                                        {isCompleted && (
-                                            <div className="size-7 rounded-full bg-[#EFF3E4] border border-[#7D9433] flex items-center justify-center">
-                                                <Check className="size-4 text-[#7D9433] stroke-[3]" />
-                                            </div>
-                                        )}
+                                            {isPending && (
+                                                <div className="size-7 rounded-full bg-white border-2 border-[#EAEAEA] flex items-center justify-center">
+                                                    <div className="size-2.5 rounded-full bg-[#EAEAEA]" />
+                                                </div>
+                                            )}
+                                        </div>
 
-                                        {isActive && (
-                                            <div className="size-7 rounded-full bg-white border border-[#A2B855] flex items-center justify-center">
-                                                <div className="size-3 rounded-full bg-[#7D9433]" />
-                                            </div>
-                                        )}
-
-                                        {isPending && (
-                                            <div className="size-7 rounded-full bg-white border-2 border-[#EAEAEA] flex items-center justify-center">
-                                                <div className="size-2.5 rounded-full bg-[#EAEAEA]" />
-                                            </div>
-                                        )}
+                                        <div className="space-y-0.5">
+                                            <h4
+                                                className="text-[16px] lg:text-[18px] font-medium transition-colors text-[#1A1C1E]"
+                                                style={TYPOGRAPHY.body}
+                                            >
+                                                {milestone.title}
+                                            </h4>
+                                            <p className="text-[14px] lg:text-[16px] text-[#A1A1A1] leading-normal">
+                                                {milestone.description}
+                                            </p>
+                                        </div>
                                     </div>
 
-                                    {/* Metadata Descriptive Headers */}
-                                    <div className="space-y-0.5">
-                                        <h4 className="text-[16px] lg:text-[18px] font-medium transition-colors text-[#1A1C1E]"
-                                            style={TYPOGRAPHY.body}
-                                        >
-                                            {milestone.title}
-                                        </h4>
-                                        <p className="text-[14px] lg:text-[16px] text-[#A1A1A1] leading-normal">
-                                            {milestone.description}
-                                        </p>
+                                    <div className="flex flex-col items-end gap-1 lg:gap-1.5 pt-0.5 text-right select-none">
+                                        <span className={cn(
+                                            "text-[16px] lg:text-[18px] font-medium tracking-tight",
+                                            isCompleted && "text-[#7D8A26]",
+                                            isActive && "text-[#7D8A26]",
+                                            isPending && "text-[#858585]"
+                                        )}>
+                                            {milestone.dateLabel}
+                                        </span>
+
+                                        <span className={cn(
+                                            "text-[12px] lg:text-[14px] text-center  font-medium capitalize tracking-wider px-2 py-0.5 rounded-[3px] w-[96px] lg:w-[102px]",
+                                            isCompleted && "bg-[#D0FFC2] text-[#45B424]",
+                                            isActive && "bg-[#EBF5A6] text-[#A7B832]",
+                                            isPending && "bg-[#EAEAEA] text-[#858585]"
+                                        )}>
+                                            {status}
+                                        </span>
                                     </div>
                                 </div>
-
-                                {/* Right Block: Deadline Tags / Historical Logs */}
-                                <div className="flex flex-col items-end gap-1 lg:gap-1.5 pt-0.5 text-right select-none">
-                                    <span className={cn(
-                                        "text-[16px] lg:text-[18px] font-medium tracking-tight",
-                                        isCompleted && "text-[#7D8A26]",
-                                        isActive && "text-[#7D8A26]",
-                                        isPending && "text-[#858585]"
-                                    )}>
-                                        {milestone.dateLabel}
-                                    </span>
-
-                                    {/* Status Pill Badge Labels */}
-                                    <span className={cn(
-                                        "text-[12px] lg:text-[14px] text-center  font-medium capitalize tracking-wider px-2 py-0.5 rounded-[3px] w-[96px] lg:w-[102px]",
-                                        isCompleted && "bg-[#D0FFC2] text-[#45B424]",
-                                        isActive && "bg-[#EBF5A6] text-[#A7B832]",
-                                        isPending && "bg-[#EAEAEA] text-[#858585]"
-                                    )}>
-                                        {milestone.status}
-                                    </span>
-                                </div>
-
-                            </div>
-                        )
-                    })}
-                </div>
+                            )
+                        })}
+                    </div>
+                )}
             </CardContent>
         </Card>
     )

--- a/src/app/(dashboard)/dashboard/components/investor-breakdown-chart.tsx
+++ b/src/app/(dashboard)/dashboard/components/investor-breakdown-chart.tsx
@@ -6,34 +6,36 @@ import { ChevronDown } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import { TYPOGRAPHY } from "@/constants/styles"
+import type { FundraiserBreakdownBucket } from "@/types/fundraiser-dashboard-api"
 
-interface BreakdownChartItem {
-    range: string
-    percentage: number // e.g., 20
-    colorClass: string
+const BUCKET_COLORS = ["bg-[#C49132]", "bg-[#3B75BE]", "bg-[#80AC49]", "bg-[#A792CD]"]
+
+interface InvestorBreakdownChartProps {
+    buckets?: FundraiserBreakdownBucket[]
+    isLoading?: boolean
 }
 
-export function InvestorBreakdownChart() {
+export function InvestorBreakdownChart({
+    buckets = [],
+    isLoading = false,
+}: InvestorBreakdownChartProps) {
     const [filterValue, setFilterValue] = useState("size")
 
-    const chartData: BreakdownChartItem[] = [
-        { range: "0 - 5M", percentage: 20, colorClass: "bg-[#C49132]" },
-        { range: "6M - 20M", percentage: 40, colorClass: "bg-[#3B75BE]" },
-        { range: "21M - 100M", percentage: 30, colorClass: "bg-[#80AC49]" },
-        { range: "101M - 500M", percentage: 10, colorClass: "bg-[#A792CD]" },
-    ]
+    const chartData = buckets.map((bucket, idx) => ({
+        range: bucket.label,
+        percentage: bucket.percentage,
+        colorClass: BUCKET_COLORS[idx % BUCKET_COLORS.length],
+    }))
 
     const yAxisMarkers = [100, 90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
 
     return (
         <Card className="w-full border-[#EAEAEA] shadow-none rounded-md bg-white overflow-hidden p-4">
-            {/* Header Container with Radix Select Wrapper */}
             <CardHeader className="flex flex-row items-center justify-between p-0 space-y-0">
                 <CardTitle className="text-[16px] text-[#1A1C1E]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
                     Investor Breakdown
                 </CardTitle>
 
-                {/* Radix UI Select Configuration */}
                 <Select.Root value={filterValue} onValueChange={setFilterValue}>
                     <Select.Trigger
                         className="inline-flex items-center justify-between gap-4 px-4 py-2 text-[16px] text-[#11110F] border border-[#CCCCCC] rounded-md bg-white hover:bg-[#F9FAFA] transition-colors focus:outline-none min-w-[110px]"
@@ -70,11 +72,8 @@ export function InvestorBreakdownChart() {
                 </Select.Root>
             </CardHeader>
 
-            {/* Grid Content Layout Container */}
             <CardContent className="px-0 pt-4 pb-0.5">
-                <div className="relative h-[260px] w-full flex flex-col justify-between">
-
-                    {/* Background Grid Guidelines with Y-Axis Values */}
+                <div className={cn("relative h-[260px] w-full flex flex-col justify-between", isLoading && "animate-pulse opacity-60")}>
                     <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
                         {yAxisMarkers.map((marker) => (
                             <div key={marker} className="w-full flex items-center gap-4 group">
@@ -89,11 +88,9 @@ export function InvestorBreakdownChart() {
                         ))}
                     </div>
 
-                    {/* Active Data Bar Tracks */}
                     <div className="absolute left-12 right-4 bottom-0 top-0 flex justify-between items-end z-10 gap-3 md:gap-4 px-2">
                         {chartData.map((bar, idx) => (
                             <div key={idx} className="flex flex-col items-center flex-1 h-full max-w-[52px] justify-end">
-                                {/* Dynamic Height Filled Column Segment */}
                                 <div
                                     className={cn(
                                         "w-full rounded-t-[4px] transition-all duration-700 ease-out shadow-xs",
@@ -104,10 +101,8 @@ export function InvestorBreakdownChart() {
                             </div>
                         ))}
                     </div>
+                </div>
 
-                </div> {/* This closes the relative h-[260px] Chart Matrix wrapper */}
-
-                {/* NEW: Clean, isolated X-Axis Label Track running parallel with chart items */}
                 <div className="flex justify-between items-start left-12 right-4 ml-12 mr-4 mt-2 gap-3 md:gap-4 px-2">
                     {chartData.map((bar, idx) => (
                         <div key={idx} className="flex-1 max-w-[52px] text-center">
@@ -117,9 +112,6 @@ export function InvestorBreakdownChart() {
                         </div>
                     ))}
                 </div>
-
-
-
             </CardContent>
         </Card>
     )

--- a/src/app/(dashboard)/dashboard/components/section-cards.tsx
+++ b/src/app/(dashboard)/dashboard/components/section-cards.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import { TYPOGRAPHY } from "@/constants/styles"
 import type { DashboardSummary } from "@/types/dashboard-api"
+import type { FundraiserDashboardSummary } from "@/types/fundraiser-dashboard-api"
 import { UserType } from "@/store/userStore"
 
 const formatCurrency = (val: string | number) => {
@@ -141,38 +142,45 @@ function SummaryCard({
 
 interface SectionCardsProps {
   summary?: DashboardSummary
+  fundraiserSummary?: FundraiserDashboardSummary
   isLoading?: boolean
   state?: boolean
   userType?: UserType
 }
 
-export function SectionCards({ summary, isLoading = false, state = false, userType = "individual" }: SectionCardsProps) {
+export function SectionCards({
+  summary,
+  fundraiserSummary,
+  isLoading = false,
+  state = false,
+  userType = "individual",
+}: SectionCardsProps) {
   const useMock = summary === undefined && state
   const isFundraiser = userType === "fundraiser"
 
   const fundraiserCardData = [
     {
       title: "Total Amount Raised",
-      value: formatFundraiserCurrency(useMock ? 245000000 : (summary?.totalInvested ?? 0), false),
+      value: formatFundraiserCurrency(fundraiserSummary?.totalAmountRaised ?? 0, false),
       icon: Wallet,
       isPrimary: true,
       isFundraiserView: true
     },
     {
       title: "Total Number of Investors",
-      value: formatFundraiserCurrency(useMock ? 128 : (summary?.totalReturns ?? 0), false),
+      value: formatFundraiserCurrency(fundraiserSummary?.totalInvestors ?? 0, false),
       icon: HandCoins,
       isFundraiserView: true
     },
     {
       title: "Days Remaining",
-      value: String(useMock ? 18 : 0),
+      value: String(fundraiserSummary?.daysRemaining ?? 0),
       icon: TrendingUp,
       isFundraiserView: true
     },
     {
       title: "Avg. Investment Size",
-      value: formatFundraiserCurrency(useMock ? 196314 : (summary?.availableBalance ?? 0), true),
+      value: formatFundraiserCurrency(fundraiserSummary?.averageInvestmentSize ?? 0, true),
       icon: TrendingUp,
       isFundraiserView: true
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const CACHE_KEY_USER = ["user"] as const;
 export const CACHE_KEY_INVESTMENTS = ["investments"] as const;
 export const CACHE_KEY_DASHBOARD = ["dashboard"] as const;
+export const CACHE_KEY_FUNDRAISER_DASHBOARD = ["fundraiser-dashboard"] as const;
 export const CACHE_KEY_WALLET_TRANSACTIONS = ["wallet-transactions"] as const;
 export const CACHE_KEY_PAYMENT_METHODS = ["payment-methods"] as const;
 export const CACHE_KEY_WATCHLIST = ["watchlist"] as const;

--- a/src/hooks/use-dashboard.ts
+++ b/src/hooks/use-dashboard.ts
@@ -2,10 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { CACHE_KEY_DASHBOARD } from "@/constants";
 import dashboardService from "@/services/dashboardService";
 
-export function useDashboard(period: string) {
+export function useDashboard(period: string, enabled = true) {
   return useQuery({
     queryKey: [...CACHE_KEY_DASHBOARD, period],
     queryFn: () => dashboardService.getDashboard(period),
-    enabled: Boolean(period),
+    enabled: enabled && Boolean(period),
   });
 }

--- a/src/hooks/use-fundraiser-dashboard.ts
+++ b/src/hooks/use-fundraiser-dashboard.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { CACHE_KEY_FUNDRAISER_DASHBOARD } from "@/constants";
+import fundraiserDashboardService from "@/services/fundraiserDashboardService";
+
+export function useFundraiserDashboard(period: string, enabled = true) {
+  return useQuery({
+    queryKey: [...CACHE_KEY_FUNDRAISER_DASHBOARD, period],
+    queryFn: () => fundraiserDashboardService.getDashboard(period),
+    enabled: enabled && Boolean(period),
+  });
+}

--- a/src/services/fundraiserDashboardService.ts
+++ b/src/services/fundraiserDashboardService.ts
@@ -1,0 +1,23 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type { FundraiserDashboardResponse } from "@/types/fundraiser-dashboard-api";
+import { toApiError } from "@/lib/api-error";
+
+const BASE = "/api/fundraisers/me/dashboard";
+
+async function getDashboard(period: string): Promise<FundraiserDashboardResponse> {
+  try {
+    const res = await request.get<ApiResponse<FundraiserDashboardResponse>>(BASE, {
+      params: { period },
+    });
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const fundraiserDashboardService = {
+  getDashboard,
+};
+
+export default fundraiserDashboardService;

--- a/src/types/fundraiser-dashboard-api.ts
+++ b/src/types/fundraiser-dashboard-api.ts
@@ -1,0 +1,46 @@
+export interface FundraiserDashboardSummary {
+  totalAmountRaised: number;
+  totalInvestors: number;
+  daysRemaining: number;
+  averageInvestmentSize: number;
+}
+
+export interface FundraiserFundingProgress {
+  raisedAmount: number;
+  targetAmount: number;
+  minimumThreshold: number;
+  currentVelocity: number;
+  velocityPeriod: string;
+  confidenceRate: number;
+}
+
+export interface FundraiserBreakdownBucket {
+  label: string;
+  percentage: number;
+}
+
+export interface FundraiserInvestorBreakdown {
+  dimension: string;
+  buckets: FundraiserBreakdownBucket[];
+}
+
+export type FundraiserMilestoneStatus = "completed" | "active" | "pending";
+
+export interface FundraiserMilestone {
+  key: string;
+  title: string;
+  description: string;
+  dateLabel: string;
+  status: FundraiserMilestoneStatus;
+}
+
+export interface FundraiserDashboardResponse {
+  offeringId: number | null;
+  offeringSlug: string | null;
+  offeringName: string | null;
+  currency: string;
+  summary: FundraiserDashboardSummary;
+  fundingProgress: FundraiserFundingProgress;
+  investorBreakdown: FundraiserInvestorBreakdown;
+  milestones: FundraiserMilestone[];
+}


### PR DESCRIPTION
## Summary
- Add fundraiser dashboard types, service, and React Query hook for `GET /api/fundraisers/me/dashboard`.
- Replace fundraiser mock summary/progress/breakdown/milestones with live API data.
- Keep investor dashboard path unchanged (investor hook disabled for fundraisers).

## Test plan
- [ ] Point UI at local API and restart `pnpm dev`
- [ ] Login as fundraiser → `/dashboard` shows live raised/investors/days/avg (not hardcoded ₦142.5M mock)
- [ ] Funding progress, investor breakdown, and milestones match API response
- [ ] Login as investor → investor dashboard still works as before
- [ ] Depends on API PR: fundraiser dashboard endpoint + offering ownership


Made with [Cursor](https://cursor.com)