### PR TITLE
Wire fundraiser Analytics page to API

### DIFF
--- a/src/app/(dashboard)/analytics/components/Analytics.tsx
+++ b/src/app/(dashboard)/analytics/components/Analytics.tsx
@@ -1,22 +1,43 @@
+"use client"
+
+import { useEffect } from 'react'
 import { AnalyticsHeader } from '@/components/analytics/AnalyticsHeader'
 import { AnalyticsOverviewGrid } from '@/components/analytics/AnalyticsOverviewGrid'
 import { ConversionMetricsCard } from '@/components/analytics/ConversionMetricsCard'
 import { InvestorDiversityCard } from '@/components/analytics/InvestorDiversityCard'
 import { TrafficConversionChart } from '@/components/analytics/TrafficConversionChart'
+import { useFundraiserAnalytics } from '@/hooks/use-fundraiser-analytics'
+import { showApiErrorToast } from '@/lib/error-feedback'
 
 export default function Analytics() {
+    const analyticsQuery = useFundraiserAnalytics('last-7-days')
+    const data = analyticsQuery.data
+    const isLoading = analyticsQuery.isLoading
+
+    useEffect(() => {
+        if (analyticsQuery.isError) {
+            showApiErrorToast(analyticsQuery.error, 'Unable to load analytics.')
+        }
+    }, [analyticsQuery.isError, analyticsQuery.error])
+
     return (
         <div>
-            <AnalyticsHeader />
+            <AnalyticsHeader exportDisabled />
 
-            <AnalyticsOverviewGrid />
+            {!isLoading && data && !data.offeringId ? (
+                <div className="mb-6 rounded-xl border border-[#EAEAEA] bg-white p-6 text-sm text-[#505050]">
+                    No owned campaign found yet. Analytics will appear once your offering is published.
+                </div>
+            ) : null}
 
-            <div className='my-6 grid lg:grid-cols-2 gap-4'>
-                <TrafficConversionChart />
-                <InvestorDiversityCard />
+            <AnalyticsOverviewGrid overview={data?.overview} isLoading={isLoading} />
+
+            <div className="my-6 grid lg:grid-cols-2 gap-4">
+                <TrafficConversionChart traffic={data?.traffic} isLoading={isLoading} />
+                <InvestorDiversityCard diversity={data?.diversity} isLoading={isLoading} />
             </div>
 
-            <ConversionMetricsCard />
+            <ConversionMetricsCard conversion={data?.conversion} isLoading={isLoading} />
         </div>
     )
 }

--- a/src/components/analytics/AnalyticsHeader.tsx
+++ b/src/components/analytics/AnalyticsHeader.tsx
@@ -4,45 +4,38 @@ import { FileText, Download } from 'lucide-react'
 import { TYPOGRAPHY } from '@/constants/styles'
 import { OnboardingButton } from '../onboarding/molecules/OnboardingButton'
 
-export function AnalyticsHeader() {
+interface AnalyticsHeaderProps {
+    exportDisabled?: boolean
+}
 
+export function AnalyticsHeader({ exportDisabled = true }: AnalyticsHeaderProps) {
     return (
         <div className="w-full bg-transparent py-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 font-sans border-b border-[#F4F5F7] mb-6">
-
-            {/* Title and Description Labels */}
             <div className="space-y-1">
-
                 <h1 className="text-[20px] lg:text-[28px] text-[#1F1F1F]" style={TYPOGRAPHY.heading}>
                     Advanced Analytics
                 </h1>
                 <p className="text-[14px] lg:text-[16px] text-[#505050]" style={TYPOGRAPHY.body}>
                     Comprehensive campaign performance and performance insights.
                 </p>
-
             </div>
 
-            {/* Action Button Controls Toolbar */}
             <div className="flex items-center gap-3">
-
-                {/* Export PDF Secondary Action Option Button */}
-
                 <OnboardingButton
-                    variant='plain'
-                    label='Export PDF'
+                    variant="plain"
+                    label="Export PDF"
+                    disabled={exportDisabled}
                     icon={<FileText className="w-4 h-4 text-[#333333]" />}
-                    className='my-0 w-fit border-[#EAEAEA] text-[14px] font-normal bg-white'
-
+                    className="my-0 w-fit border-[#EAEAEA] text-[14px] font-normal bg-white"
                 />
 
                 <OnboardingButton
-                    label='Export CSV'
+                    label="Export CSV"
+                    disabled={exportDisabled}
                     icon={<Download className="w-4 h-4 text-white" />}
-                    className='my-0 w-fit text-[14px] font-normal'
-
+                    className="my-0 w-fit text-[14px] font-normal"
                 />
-
             </div>
-
         </div>
     )
 }

--- a/src/components/analytics/AnalyticsOverviewGrid.tsx
+++ b/src/components/analytics/AnalyticsOverviewGrid.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Eye, ThumbsUp, Share2 } from 'lucide-react'
+import type { FundraiserAnalyticsOverview } from '@/types/fundraiser-analytics-api'
 
 interface MetricCardProps {
     title: string
@@ -13,8 +14,6 @@ interface MetricCardProps {
 function MetricCard({ title, value, icon, iconBgColor, iconColor }: MetricCardProps) {
     return (
         <div className="flex-1 bg-white border border-[#EAEAEA] rounded-xl p-4 flex items-center gap-5 min-w-[240px]">
-
-            {/* Icon Wrapper Container */}
             <div
                 className="w-14 h-14 rounded-lg flex items-center justify-center shrink-0"
                 style={{ backgroundColor: iconBgColor }}
@@ -24,7 +23,6 @@ function MetricCard({ title, value, icon, iconBgColor, iconColor }: MetricCardPr
                 </div>
             </div>
 
-            {/* Metric Details Label Meta Text */}
             <div className="space-y-1">
                 <span className="text-[16px] text-[#858585] font-medium block">
                     {title}
@@ -33,34 +31,42 @@ function MetricCard({ title, value, icon, iconBgColor, iconColor }: MetricCardPr
                     {value}
                 </span>
             </div>
-
         </div>
     )
 }
 
-export function AnalyticsOverviewGrid() {
+interface AnalyticsOverviewGridProps {
+    overview?: FundraiserAnalyticsOverview | null
+    isLoading?: boolean
+}
+
+function formatCount(value: number) {
+    return value.toLocaleString('en-US')
+}
+
+export function AnalyticsOverviewGrid({ overview = null, isLoading = false }: AnalyticsOverviewGridProps) {
     const metricsData = [
         {
-            title: "Total page views",
-            value: "42,891",
+            title: 'Total page views',
+            value: isLoading ? '—' : formatCount(overview?.totalPageViews ?? 0),
             icon: <Eye className="w-6 h-6" />,
-            iconBgColor: "#EDF4FC",
-            iconColor: "#4A90E2"
+            iconBgColor: '#EDF4FC',
+            iconColor: '#4A90E2',
         },
         {
-            title: "Campaign likes",
-            value: "12,460",
+            title: 'Campaign likes',
+            value: isLoading ? '—' : formatCount(overview?.campaignLikes ?? 0),
             icon: <ThumbsUp className="w-6 h-6 stroke-[1.75]" />,
-            iconBgColor: "#F6FBEF",
-            iconColor: "#A4D65E"
+            iconBgColor: '#F6FBEF',
+            iconColor: '#A4D65E',
         },
         {
-            title: "Social shares",
-            value: "1,803",
+            title: 'Social shares',
+            value: isLoading ? '—' : formatCount(overview?.socialShares ?? 0),
             icon: <Share2 className="w-6 h-6" />,
-            iconBgColor: "#EDF0F5",
-            iconColor: "#46699D"
-        }
+            iconBgColor: '#EDF0F5',
+            iconColor: '#46699D',
+        },
     ]
 
     return (

--- a/src/components/analytics/ConversionMetricsCard.tsx
+++ b/src/components/analytics/ConversionMetricsCard.tsx
@@ -1,57 +1,61 @@
 "use client"
 
 import React from 'react'
+import type { FundraiserAnalyticsConversion } from '@/types/fundraiser-analytics-api'
 
-interface MetricItem {
-    label: string
-    value: string
+interface ConversionMetricsCardProps {
+    conversion?: FundraiserAnalyticsConversion | null
+    isLoading?: boolean
 }
 
-export function ConversionMetricsCard() {
-    // Analytical list tracking metrics data points
-    const metricsList: MetricItem[] = [
+function formatRate(rate: number) {
+    return `${(rate * 100).toFixed(1).replace(/\.0$/, '')}%`
+}
+
+function formatDurationHours(hours: number | null | undefined) {
+    if (hours == null || Number.isNaN(hours)) return '—'
+    if (hours < 1) return `${Math.max(1, Math.round(hours * 60))}m`
+    if (hours < 48) return `${hours.toFixed(1).replace(/\.0$/, '')}h`
+    const days = hours / 24
+    return `${days.toFixed(1).replace(/\.0$/, '')}d`
+}
+
+export function ConversionMetricsCard({
+    conversion = null,
+    isLoading = false,
+}: ConversionMetricsCardProps) {
+    const metricsList = [
         {
-            label: "View-to-investment rate",
-            value: "5.9%"
+            label: 'View-to-investment rate',
+            value: isLoading ? '—' : formatRate(conversion?.viewToInvestmentRate ?? 0),
         },
         {
-            label: "Average time to invest",
-            value: "24%"
+            label: 'Average time to invest',
+            value: isLoading ? '—' : formatDurationHours(conversion?.averageTimeToInvestHours),
         },
         {
-            label: "Return visitors",
-            value: "41%"
-        }
+            label: 'Return visitors',
+            value: isLoading ? '—' : formatRate(conversion?.returnVisitorRate ?? 0),
+        },
     ]
 
     return (
         <div className="w-full bg-white border border-[#F4F5F7] rounded-xl p-6 font-sans">
-
-            {/* Container Module Header Label */}
             <h3 className="text-[#1B1B1B] text-[14px] lg:text-[16px] font-medium tracking-tight mb-5">
                 Conversion Metrics
             </h3>
 
-            {/* Row List Breakdown Block */}
             <div>
-                {metricsList.map((metric, index) => (
+                {metricsList.map((metric) => (
                     <div
-                        key={index}
+                        key={metric.label}
                         className="flex items-center justify-between py-4 border-b border-[#EAEAEA] first:pt-2 last:pb-2 text-sm"
                     >
-                        {/* Descriptive Variable Label */}
-                        <span className="text-[#858585] font-medium">
-                            {metric.label}
-                        </span>
-
-                        {/* Numerical Performance Value Data Indicator */}
-                        <span className="text-[#858585] font-medium text-right">
-                            {metric.value}
-                        </span>
+                        <span className="text-[#858585] font-medium">{metric.label}</span>
+                        <span className="text-[#858585] font-medium text-right">{metric.value}</span>
                     </div>
                 ))}
             </div>
-
         </div>
     )
 }

--- a/src/components/analytics/InvestorDiversityCard.tsx
+++ b/src/components/analytics/InvestorDiversityCard.tsx
@@ -2,91 +2,107 @@
 
 import React from 'react'
 import { Map, Users } from 'lucide-react'
+import type { FundraiserAnalyticsDiversity } from '@/types/fundraiser-analytics-api'
 
-export function InvestorDiversityCard() {
-    // Geographic segment data structures
-    const geoSegments = [
-        { label: "West Africa", percentage: 65, color: "bg-[#7D8A26]" },
-        { label: "Europe", percentage: 20, color: "bg-[#4A90E2]" },
-        { label: "Americas", percentage: 10, color: "bg-[#F4B942]" },
-        { label: "Other", percentage: 5, color: "bg-[#EFF4E4]" },
-    ]
+const GEO_COLORS = ['bg-[#7D8A26]', 'bg-[#4A90E2]', 'bg-[#F4B942]', 'bg-[#EFF4E4]']
+const CATEGORY_COLORS = ['bg-[#4A90E2]', 'bg-[#F4B942]', 'bg-[#7D8A26]', 'bg-[#A7B832]', 'bg-[#858585]']
 
-    // Individual categorical breakdown items
-    const investorCategories = [
-        { name: "Tech Enthusiasts", percentage: 72, color: "bg-[#4A90E2]" },
-        { name: "Real Estate Investors", percentage: 18, color: "bg-[#F4B942]" },
-        { name: "Fintech HNIs", percentage: 10, color: "bg-[#7D8A26]" },
-    ]
+interface InvestorDiversityCardProps {
+    diversity?: FundraiserAnalyticsDiversity | null
+    isLoading?: boolean
+}
+
+export function InvestorDiversityCard({ diversity = null, isLoading = false }: InvestorDiversityCardProps) {
+    const geoSegments = (diversity?.geographic ?? []).map((segment, index) => ({
+        label: segment.label,
+        percentage: segment.percentage,
+        color: GEO_COLORS[index % GEO_COLORS.length],
+    }))
+
+    const investorCategories = (diversity?.categories ?? []).map((category, index) => ({
+        name: category.label,
+        percentage: category.percentage,
+        color: CATEGORY_COLORS[index % CATEGORY_COLORS.length],
+    }))
 
     return (
         <div className="w-full max-w-[640px] bg-white border border-[#F4F5F7] rounded-xl p-6 font-sans">
-
-            {/* Title Segment Header */}
             <h3 className="text-[#1B1B1B] text-[14px] lg:text-[16px] font-medium tracking-tight mb-6">
                 Investor Diversity
             </h3>
 
-            {/* --- GEOGRAPHIC DISTRIBUTION SECTION --- */}
-            <div className="mb-8">
-                <div className="flex items-center justify-between mb-3">
-                    <div className="flex items-center gap-2 text-[#1B1B1B]">
-                        <Map className="w-5 h-5 text-[#717171] stroke-[1.75]" />
-                        <span className="text-[14px] lg:text-[16px] font-medium">Geographic Distribution</span>
-                    </div>
-                    <span className="text-xs text-[#858585]">Top: Lagos, NG</span>
+            {isLoading ? (
+                <div className="py-10 text-center text-sm text-[#717171]">Loading diversity…</div>
+            ) : geoSegments.length === 0 && investorCategories.length === 0 ? (
+                <div className="py-10 text-center text-sm text-[#717171]">
+                    No investor diversity data yet.
                 </div>
-
-                {/* Multi-segmented distribution line bar */}
-                <div className="w-full h-3 rounded-full flex overflow-hidden bg-[#EDF1D6] mb-3">
-                    {geoSegments.map((segment) => (
-                        <div
-                            key={segment.label}
-                            className={`${segment.color} h-full`}
-                            style={{ width: `${segment.percentage}%` }}
-                        />
-                    ))}
-                </div>
-
-                {/* Legend Indicators Meta text wrapper */}
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[#858585]">
-                    {geoSegments.slice(0, 2).map((segment) => (
-                        <div key={segment.label} className="flex items-center gap-1.5">
-                            <span className={`w-2 h-2 rounded-full ${segment.color}`} />
-                            <span>{segment.label} ({segment.percentage}%)</span>
-                        </div>
-                    ))}
-                </div>
-            </div>
-
-            {/* --- INVESTOR CATEGORIES SECTION --- */}
-            <div>
-                <div className="flex items-center gap-2 text-[#1F1F1F] mb-5">
-                    <Users className="w-5 h-5 text-[#858585] stroke-[1.75]" />
-                    <span className="text-[16px] font-medium">Investor Categories</span>
-                </div>
-
-                {/* Categorization list loop block */}
-                <div className="space-y-4">
-                    {investorCategories.map((category) => (
-                        <div key={category.name} className="space-y-1.5">
-                            <div className="flex items-center justify-between text-[14px] text-[#858585]">
-                                <span className="font-medium">{category.name}</span>
-                                <span className="font-medium">{category.percentage}%</span>
+            ) : (
+                <>
+                    <div className="mb-8">
+                        <div className="flex items-center justify-between mb-3">
+                            <div className="flex items-center gap-2 text-[#1B1B1B]">
+                                <Map className="w-5 h-5 text-[#717171] stroke-[1.75]" />
+                                <span className="text-[14px] lg:text-[16px] font-medium">
+                                    Geographic Distribution
+                                </span>
                             </div>
+                            <span className="text-xs text-[#858585]">
+                                {diversity?.topLocation ? `Top: ${diversity.topLocation}` : 'Top: —'}
+                            </span>
+                        </div>
 
-                            {/* Individual Base Bar Component TRACK */}
-                            <div className="w-full h-3 rounded-full bg-[#EDF1D6] overflow-hidden">
+                        <div className="w-full h-3 rounded-full flex overflow-hidden bg-[#EDF1D6] mb-3">
+                            {geoSegments.map((segment) => (
                                 <div
-                                    className={`h-full rounded-full ${category.color} transition-all duration-500`}
-                                    style={{ width: `${category.percentage}%` }}
+                                    key={segment.label}
+                                    className={`${segment.color} h-full`}
+                                    style={{ width: `${segment.percentage}%` }}
                                 />
-                            </div>
+                            ))}
                         </div>
-                    ))}
-                </div>
-            </div>
 
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[#858585]">
+                            {geoSegments.slice(0, 2).map((segment) => (
+                                <div key={segment.label} className="flex items-center gap-1.5">
+                                    <span className={`w-2 h-2 rounded-full ${segment.color}`} />
+                                    <span>
+                                        {segment.label} ({segment.percentage}%)
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div>
+                        <div className="flex items-center gap-2 text-[#1F1F1F] mb-5">
+                            <Users className="w-5 h-5 text-[#858585] stroke-[1.75]" />
+                            <span className="text-[16px] font-medium">Investor Categories</span>
+                        </div>
+
+                        {investorCategories.length === 0 ? (
+                            <p className="text-sm text-[#717171]">No category breakdown yet.</p>
+                        ) : (
+                            <div className="space-y-4">
+                                {investorCategories.map((category) => (
+                                    <div key={category.name} className="space-y-1.5">
+                                        <div className="flex items-center justify-between text-[14px] text-[#858585]">
+                                            <span className="font-medium">{category.name}</span>
+                                            <span className="font-medium">{category.percentage}%</span>
+                                        </div>
+                                        <div className="w-full h-3 rounded-full bg-[#EDF1D6] overflow-hidden">
+                                            <div
+                                                className={`h-full rounded-full ${category.color} transition-all duration-500`}
+                                                style={{ width: `${category.percentage}%` }}
+                                            />
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </>
+            )}
         </div>
     )
 }

--- a/src/components/analytics/TrafficConversionChart.tsx
+++ b/src/components/analytics/TrafficConversionChart.tsx
@@ -1,28 +1,39 @@
 "use client"
 
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
+import type { FundraiserAnalyticsTraffic } from '@/types/fundraiser-analytics-api'
 
-interface DataPoint {
-    day: string
-    value: number // Percentage height for bar (0 - 100)
-    displayValue: string // Value shown on hover/selection
+interface TrafficConversionChartProps {
+    traffic?: FundraiserAnalyticsTraffic | null
+    isLoading?: boolean
 }
 
-export function TrafficConversionChart() {
-    const chartData: DataPoint[] = [
-        { day: 'Mon', value: 23, displayValue: '2300' },
-        { day: 'Tue', value: 44, displayValue: '4400' },
-        { day: 'Wed', value: 35, displayValue: '3500' },
-        { day: 'Thu', value: 10, displayValue: '1000' },
-        { day: 'Fri', value: 70, displayValue: '9600' },
-        { day: 'Sat', value: 35, displayValue: '3500' },
-        { day: 'Sun', value: 51, displayValue: '5100' },
-    ]
+function formatAverageBadge(averagePerDay: number) {
+    if (averagePerDay >= 1000) {
+        const k = averagePerDay / 1000
+        const rounded = k >= 10 ? Math.round(k) : Math.round(k * 10) / 10
+        return `Avg: ${rounded}k / day`
+    }
+    return `Avg: ${Math.round(averagePerDay).toLocaleString('en-US')} / day`
+}
+
+export function TrafficConversionChart({ traffic = null, isLoading = false }: TrafficConversionChartProps) {
+    const chartData = useMemo(() => {
+        const points = traffic?.points ?? []
+        if (points.length === 0) {
+            return []
+        }
+        const max = Math.max(...points.map((p) => p.value), 1)
+        return points.map((point) => ({
+            day: point.label,
+            value: Math.max(2, Math.round((point.value / max) * 100)),
+            displayValue: point.value.toLocaleString('en-US'),
+        }))
+    }, [traffic?.points])
 
     const [activeIndex, setActiveIndex] = useState<number | null>(null)
     const [mouseY, setMouseY] = useState<number>(0)
 
-    // 6 ticks create 5 perfectly equal vertical spans (100-80, 80-60, 60-40, 40-20, 20-0)
     const yAxisTicks = [100, 80, 60, 40, 20, 0]
 
     const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -33,113 +44,113 @@ export function TrafficConversionChart() {
 
     return (
         <div className="w-full bg-white border border-[#F4F5F7] rounded-xl p-6 font-sans">
-
-            {/* Header Metric Row Summary */}
             <div className="flex items-center justify-between mb-8">
                 <h3 className="text-[#1B1B1B] text-base lg:text-[18px] font-medium tracking-tight">
                     Traffic & Conversion velocity
                 </h3>
                 <span className="bg-[#EBF7EE] text-[#22C55E] text-xs font-medium px-2.5 py-1 rounded-full">
-                    Avg: 4.8k / day
+                    {isLoading ? 'Loading…' : formatAverageBadge(traffic?.averagePerDay ?? 0)}
                 </span>
             </div>
 
-            {/* Main Chart Framework Workspace - Scaled to 484px */}
-            <div className="relative flex h-[392px] w-full">
-
-                {/* Left Hand Y-Axis Numerical Reference Labels - Distributed Evenly */}
-                <div className="flex flex-col justify-between text-xs text-[#999999] pr-4 select-none h-[calc(100%-24px)] text-right w-8">
-                    {yAxisTicks.map((tick) => (
-                        <span key={tick} className="leading-none flex items-center justify-end h-0">
-                            {tick}
-                        </span>
-                    ))}
+            {isLoading ? (
+                <div className="h-[392px] flex items-center justify-center text-sm text-[#717171]">
+                    Loading traffic…
                 </div>
-
-                {/* Content Viewbox Canvas Area */}
-                <div className="relative flex-1 h-full">
-
-                    {/* BACKGROUND LAYER: Horizontal Alignment Guidelines Grid Matrix - Distributed Evenly */}
-                    <div className="absolute inset-0 flex flex-col justify-between h-[calc(100%-24px)] pointer-events-none z-0">
+            ) : chartData.length === 0 ? (
+                <div className="h-[392px] flex items-center justify-center text-sm text-[#717171]">
+                    No traffic data for this period.
+                </div>
+            ) : (
+                <div className="relative flex h-[392px] w-full">
+                    <div className="flex flex-col justify-between text-xs text-[#999999] pr-4 select-none h-[calc(100%-24px)] text-right w-8">
                         {yAxisTicks.map((tick) => (
-                            <div
-                                key={tick}
-                                className={`w-full border-b ${tick === 0 ? 'border-[#EAEAEA]' : 'border-[#F2F2F2]'}`}
-                            />
-                        ))}
-                    </div>
-
-                    {/* FOREGROUND LAYER: Interactive Bar Pillars Flexstrip */}
-                    <div className="absolute inset-0 z-10 h-[calc(100%-24px)] flex items-end justify-between px-4 md:px-8 gap-3 md:gap-4">
-                        {chartData.map((data, idx) => {
-                            const isActive = activeIndex === idx
-
-                            return (
-                                <div
-                                    key={idx}
-                                    role="button"
-                                    tabIndex={0}
-                                    aria-label={`${data.day}: ${data.displayValue} views`}
-                                    className="relative flex-1 h-full flex flex-col justify-end items-center cursor-pointer"
-                                    onMouseEnter={() => setActiveIndex(idx)}
-                                    onMouseLeave={() => setActiveIndex(null)}
-                                    onMouseMove={handleMouseMove}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter' || e.key === ' ') {
-                                            e.preventDefault()
-                                            setActiveIndex(idx)
-                                        }
-                                    }}
-                                    onClick={() => setActiveIndex(idx)}
-                                >
-
-                                    {/* Floating Selection Micro Tooltip Panel anchored to Cursor Height */}
-                                    {isActive && (
-                                        <div
-                                            style={{
-                                                top: `${mouseY - 58}px`
-                                            }}
-                                            className="absolute z-30 bg-white border border-[#EAEAEA] rounded-lg p-2.5 shadow-md text-xs whitespace-nowrap text-left left-1/2 -translate-x-1/2 pointer-events-none transition-all duration-75 ease-out"
-                                        >
-                                            <div className="font-medium text-[#1B1B1B]">{data.day}</div>
-                                            <div className="text-[#717171] mt-0.5">views: <span className="font-semibold text-[#1B1B1B]">{data.displayValue}</span></div>
-
-                                            {/* Tail Anchor Indicator Hook */}
-                                            <div className="absolute bottom-[-5px] left-1/2 -translate-x-1/2 w-2 h-2 bg-white border-b border-r border-[#EAEAEA] rotate-45" />
-                                        </div>
-                                    )}
-
-                                    {/* Physical Column Block Structure */}
-                                    <div
-                                        style={{
-                                            height: `${data.value}%`
-                                        }}
-                                        className={`w-full max-w-[40px] rounded-t-md transition-all duration-300 ${isActive
-                                            ? 'bg-[#A7B832]'
-                                            : 'bg-[#E0E0E0] hover:bg-[#CCCCCC]'
-                                            }`}
-                                    />
-                                </div>
-                            )
-                        })}
-                    </div>
-
-                    {/* BOTTOM LAYER: Axis Sequential Time Anchor Labels */}
-                    <div className="absolute bottom-0 left-0 right-0 flex justify-between px-4 md:px-8 h-6 text-xs text-[#999999] select-none z-10">
-                        {chartData.map((data, idx) => (
-                            <span
-                                key={idx}
-                                className={`w-full max-w-[40px] text-center pt-2 transition-colors ${activeIndex === idx ? 'text-[#1B1B1B] font-medium' : ''
-                                    }`}
-                            >
-                                {data.day}
+                            <span key={tick} className="leading-none flex items-center justify-end h-0">
+                                {tick}
                             </span>
                         ))}
                     </div>
 
-                </div>
-            </div>
+                    <div className="relative flex-1 h-full">
+                        <div className="absolute inset-0 flex flex-col justify-between h-[calc(100%-24px)] pointer-events-none z-0">
+                            {yAxisTicks.map((tick) => (
+                                <div
+                                    key={tick}
+                                    className={`w-full border-b ${tick === 0 ? 'border-[#EAEAEA]' : 'border-[#F2F2F2]'}`}
+                                />
+                            ))}
+                        </div>
 
+                        <div className="absolute inset-0 z-10 h-[calc(100%-24px)] flex items-end justify-between px-4 md:px-8 gap-3 md:gap-4">
+                            {chartData.map((data, idx) => {
+                                const isActive = activeIndex === idx
+
+                                return (
+                                    <div
+                                        key={`${data.day}-${idx}`}
+                                        role="button"
+                                        tabIndex={0}
+                                        aria-label={`${data.day}: ${data.displayValue} views`}
+                                        className="relative flex-1 h-full flex flex-col justify-end items-center cursor-pointer"
+                                        onMouseEnter={() => setActiveIndex(idx)}
+                                        onMouseLeave={() => setActiveIndex(null)}
+                                        onMouseMove={handleMouseMove}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                e.preventDefault()
+                                                setActiveIndex(idx)
+                                            }
+                                        }}
+                                        onClick={() => setActiveIndex(idx)}
+                                    >
+                                        {isActive && (
+                                            <div
+                                                style={{
+                                                    top: `${mouseY - 58}px`,
+                                                }}
+                                                className="absolute z-30 bg-white border border-[#EAEAEA] rounded-lg p-2.5 shadow-md text-xs whitespace-nowrap text-left left-1/2 -translate-x-1/2 pointer-events-none transition-all duration-75 ease-out"
+                                            >
+                                                <div className="font-medium text-[#1B1B1B]">{data.day}</div>
+                                                <div className="text-[#717171] mt-0.5">
+                                                    views:{' '}
+                                                    <span className="font-semibold text-[#1B1B1B]">
+                                                        {data.displayValue}
+                                                    </span>
+                                                </div>
+                                                <div className="absolute bottom-[-5px] left-1/2 -translate-x-1/2 w-2 h-2 bg-white border-b border-r border-[#EAEAEA] rotate-45" />
+                                            </div>
+                                        )}
+
+                                        <div
+                                            style={{
+                                                height: `${data.value}%`,
+                                            }}
+                                            className={`w-full max-w-[40px] rounded-t-md transition-all duration-300 ${
+                                                isActive
+                                                    ? 'bg-[#A7B832]'
+                                                    : 'bg-[#E0E0E0] hover:bg-[#CCCCCC]'
+                                            }`}
+                                        />
+                                    </div>
+                                )
+                            })}
+                        </div>
+
+                        <div className="absolute bottom-0 left-0 right-0 flex justify-between px-4 md:px-8 h-6 text-xs text-[#999999] select-none z-10">
+                            {chartData.map((data, idx) => (
+                                <span
+                                    key={`${data.day}-label-${idx}`}
+                                    className={`w-full max-w-[40px] text-center pt-2 transition-colors ${
+                                        activeIndex === idx ? 'text-[#1B1B1B] font-medium' : ''
+                                    }`}
+                                >
+                                    {data.day}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     )
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const CACHE_KEY_FUNDRAISER_CAMPAIGN_UPDATES = ["fundraiser-campaign-updat
 export const CACHE_KEY_FUNDRAISER_QII = ["fundraiser-qii"] as const;
 export const CACHE_KEY_FUNDRAISER_INVESTOR_MESSAGES = ["fundraiser-investor-messages"] as const;
 export const CACHE_KEY_FUNDRAISER_INVESTOR_ANALYTICS = ["fundraiser-investor-analytics"] as const;
+export const CACHE_KEY_FUNDRAISER_ANALYTICS = ["fundraiser-analytics"] as const;
 export const CACHE_KEY_WALLET_TRANSACTIONS = ["wallet-transactions"] as const;
 export const CACHE_KEY_PAYMENT_METHODS = ["payment-methods"] as const;
 export const CACHE_KEY_WATCHLIST = ["watchlist"] as const;

--- a/src/hooks/use-fundraiser-analytics.ts
+++ b/src/hooks/use-fundraiser-analytics.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { CACHE_KEY_FUNDRAISER_ANALYTICS } from "@/constants";
+import fundraiserAnalyticsService from "@/services/fundraiserAnalyticsService";
+import type { FundraiserAnalyticsPeriod } from "@/types/fundraiser-analytics-api";
+
+export function useFundraiserAnalytics(
+  period: FundraiserAnalyticsPeriod = "last-7-days",
+  enabled = true
+) {
+  return useQuery({
+    queryKey: [...CACHE_KEY_FUNDRAISER_ANALYTICS, period],
+    queryFn: () => fundraiserAnalyticsService.getAnalytics(period),
+    enabled,
+  });
+}

--- a/src/services/fundraiserAnalyticsService.ts
+++ b/src/services/fundraiserAnalyticsService.ts
@@ -1,0 +1,28 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type {
+  FundraiserAnalyticsPeriod,
+  FundraiserAnalyticsResponse,
+} from "@/types/fundraiser-analytics-api";
+import { toApiError } from "@/lib/api-error";
+
+const BASE = "/api/fundraisers/me/analytics";
+
+async function getAnalytics(
+  period: FundraiserAnalyticsPeriod = "last-7-days"
+): Promise<FundraiserAnalyticsResponse> {
+  try {
+    const res = await request.get<ApiResponse<FundraiserAnalyticsResponse>>(BASE, {
+      params: { period },
+    });
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const fundraiserAnalyticsService = {
+  getAnalytics,
+};
+
+export default fundraiserAnalyticsService;

--- a/src/types/fundraiser-analytics-api.ts
+++ b/src/types/fundraiser-analytics-api.ts
@@ -1,0 +1,45 @@
+export type FundraiserAnalyticsPeriod = "last-7-days" | "last-14-days" | "last-30-days";
+
+export interface FundraiserAnalyticsOverview {
+  totalPageViews: number;
+  campaignLikes: number;
+  socialShares: number;
+}
+
+export interface FundraiserAnalyticsTrafficPoint {
+  date: string;
+  label: string;
+  value: number;
+}
+
+export interface FundraiserAnalyticsTraffic {
+  averagePerDay: number;
+  unit: string;
+  points: FundraiserAnalyticsTrafficPoint[];
+}
+
+export interface FundraiserAnalyticsBucket {
+  label: string;
+  percentage: number;
+}
+
+export interface FundraiserAnalyticsDiversity {
+  topLocation: string | null;
+  geographic: FundraiserAnalyticsBucket[];
+  categories: FundraiserAnalyticsBucket[];
+}
+
+export interface FundraiserAnalyticsConversion {
+  viewToInvestmentRate: number;
+  averageTimeToInvestHours: number | null;
+  returnVisitorRate: number;
+}
+
+export interface FundraiserAnalyticsResponse {
+  offeringId: number | null;
+  offeringSlug: string | null;
+  overview: FundraiserAnalyticsOverview;
+  traffic: FundraiserAnalyticsTraffic;
+  diversity: FundraiserAnalyticsDiversity;
+  conversion: FundraiserAnalyticsConversion;
+}


### PR DESCRIPTION
## Summary
- Add fundraiser analytics types, service, and React Query hook
- Wire `/analytics` overview, traffic, diversity, and conversion sections to `GET /api/fundraisers/me/analytics`
- Disable Export PDF/CSV until supported; show empty-state when no owned campaign

Closes #212.

## Test plan
- [x] Sign in as fundraiser and open `/analytics`
- [x] Confirm overview, traffic chart, diversity, and conversion match API for last-7-days
- [x] Confirm Export PDF/CSV are disabled
- [x] Confirm empty owned-campaign messaging when applicable
- [x] Pair with API PR for local Aspire end-to-end check


Made with [Cursor](https://cursor.com)