### PR TITLE
Wire fundraiser documents and role 403 guards

### DIFF
--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -1,7 +1,10 @@
 import Analytics from '@/app/(dashboard)/analytics/components/Analytics'
+import { FundraiserOnly } from '@/components/auth/require-user-type'
 
 export default function page() {
     return (
-        <Analytics />
+        <FundraiserOnly>
+            <Analytics />
+        </FundraiserOnly>
     )
 }

--- a/src/app/(dashboard)/balance-funding/invoice/[id]/page.tsx
+++ b/src/app/(dashboard)/balance-funding/invoice/[id]/page.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import TransactionInvoice from '@/app/(dashboard)/balance-funding/invoice/components/TransactionInvoice'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function page() {
     return (
-        <TransactionInvoice />
+        <InvestorOnly>
+            <TransactionInvoice />
+        </InvestorOnly>
     )
 }

--- a/src/app/(dashboard)/balance-funding/page.tsx
+++ b/src/app/(dashboard)/balance-funding/page.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import BalanceFunding from '@/app/(dashboard)/balance-funding/components/BalanceFunding'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function Page() {
     return (
-        <div>
-            <BalanceFunding />
-        </div>
+        <InvestorOnly>
+            <div>
+                <BalanceFunding />
+            </div>
+        </InvestorOnly>
     )
 }

--- a/src/app/(dashboard)/campaigns/page.tsx
+++ b/src/app/(dashboard)/campaigns/page.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import Campaign from '@/app/(dashboard)/campaigns/components/Campaigns'
+import { FundraiserOnly } from '@/components/auth/require-user-type'
 
 export default function page() {
     return (
-        <Campaign />
+        <FundraiserOnly>
+            <Campaign />
+        </FundraiserOnly>
     )
 }

--- a/src/app/(dashboard)/documents/components/Documents.tsx
+++ b/src/app/(dashboard)/documents/components/Documents.tsx
@@ -1,13 +1,127 @@
-import { DocumentHeader } from '@/components/documents/molecules/DocumentHeader'
-import DocumentManagement from '@/components/documents/molecules/DocumentManagement'
-import React from 'react'
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+import { DocumentHeader } from "@/components/documents/molecules/DocumentHeader"
+import DocumentManagement from "@/components/documents/molecules/DocumentManagement"
+import { UploadDocumentDialog } from "@/components/documents/molecules/UploadDocumentDialog"
+import {
+  useFundraiserDocuments,
+  useUploadFundraiserDocument,
+} from "@/hooks/use-fundraiser-documents"
+import { showApiErrorToast } from "@/lib/error-feedback"
+import type { DocumentItem } from "@/components/documents/molecules/DocumentTable"
+import type { FundraiserDocumentStatus } from "@/types/fundraiser-documents-api"
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "—"
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "—"
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function toStatus(value: string): FundraiserDocumentStatus {
+  if (
+    value === "Approved" ||
+    value === "Pending Approval" ||
+    value === "Revision Requested"
+  ) {
+    return value
+  }
+  return "Pending Approval"
+}
 
 export default function Documents() {
-    return (
-        <div>
-            <DocumentHeader />
+  const [uploadOpen, setUploadOpen] = useState(false)
+  const documentsQuery = useFundraiserDocuments()
+  const uploadMutation = useUploadFundraiserDocument()
 
-            <DocumentManagement />
+  const data = documentsQuery.data
+  const hasOffering = Boolean(data?.offeringId)
+  const isLoading = documentsQuery.isLoading
+
+  useEffect(() => {
+    if (documentsQuery.isError) {
+      showApiErrorToast(documentsQuery.error, "Unable to load documents.")
+    }
+  }, [documentsQuery.isError, documentsQuery.error])
+
+  const documents: DocumentItem[] = useMemo(() => {
+    return (data?.items ?? []).map((item) => ({
+      id: item.id,
+      name: item.title,
+      size: formatFileSize(item.fileSizeBytes),
+      category: item.category,
+      status: toStatus(item.status),
+      lastUpdated: formatDate(item.lastUpdatedAt),
+      fileUrl: item.fileUrl,
+    }))
+  }, [data?.items])
+
+  const latestUpdatedLabel = useMemo(() => {
+    if (!data?.items?.length) return null
+    const latest = data.items.reduce((max, item) => {
+      const ts = new Date(item.lastUpdatedAt).getTime()
+      return Number.isNaN(ts) ? max : Math.max(max, ts)
+    }, 0)
+    if (!latest) return null
+    return formatDate(new Date(latest).toISOString())
+  }, [data?.items])
+
+  const handleDownload = (doc: DocumentItem) => {
+    if (!doc.fileUrl) {
+      toast.error("Download link unavailable.")
+      return
+    }
+    window.open(doc.fileUrl, "_blank", "noopener,noreferrer")
+  }
+
+  return (
+    <div>
+      <DocumentHeader
+        onUploadClick={
+          hasOffering && !uploadMutation.isPending
+            ? () => setUploadOpen(true)
+            : undefined
+        }
+      />
+
+      {!isLoading && data && !hasOffering ? (
+        <div className="mb-6 rounded-xl border border-[#EAEAEA] bg-white p-6 text-sm text-[#505050]">
+          No owned campaign found yet. Documents will appear once your offering is published.
         </div>
-    )
+      ) : null}
+
+      <DocumentManagement
+        documents={documents}
+        isLoading={isLoading}
+        latestUpdatedLabel={latestUpdatedLabel}
+        onDownload={handleDownload}
+      />
+
+      <UploadDocumentDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        isSubmitting={uploadMutation.isPending}
+        onSubmit={({ file, title, category }) => {
+          uploadMutation.mutate(
+            { file, title, category },
+            {
+              onSuccess: () => setUploadOpen(false),
+            }
+          )
+        }}
+      />
+    </div>
+  )
 }

--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -1,7 +1,10 @@
 import Documents from '@/app/(dashboard)/documents/components/Documents'
+import { FundraiserOnly } from '@/components/auth/require-user-type'
 
 export default function page() {
     return (
-        <Documents />
+        <FundraiserOnly>
+            <Documents />
+        </FundraiserOnly>
     )
 }

--- a/src/app/(dashboard)/investors/page.tsx
+++ b/src/app/(dashboard)/investors/page.tsx
@@ -1,7 +1,10 @@
 import Investors from '@/app/(dashboard)/investors/components/Investors'
+import { FundraiserOnly } from '@/components/auth/require-user-type'
 
 export default function Page() {
     return (
-        <Investors />
+        <FundraiserOnly>
+            <Investors />
+        </FundraiserOnly>
     )
 }

--- a/src/app/(dashboard)/marketplace/invest/callback/page.tsx
+++ b/src/app/(dashboard)/marketplace/invest/callback/page.tsx
@@ -1,10 +1,13 @@
 import React, { Suspense } from 'react'
 import { InvestCallbackContent } from './InvestCallbackContent'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function InvestCallbackPage() {
     return (
-        <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading…</div>}>
-            <InvestCallbackContent />
-        </Suspense>
+        <InvestorOnly>
+            <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading…</div>}>
+                <InvestCallbackContent />
+            </Suspense>
+        </InvestorOnly>
     )
 }

--- a/src/app/(dashboard)/marketplace/invest/page.tsx
+++ b/src/app/(dashboard)/marketplace/invest/page.tsx
@@ -1,10 +1,13 @@
 import React, { Suspense } from 'react'
 import { MarketPlacePayment } from '@/app/(dashboard)/marketplace/invest/MarketPlacePayment'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function page() {
     return (
-        <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading…</div>}>
-            <MarketPlacePayment />
-        </Suspense>
+        <InvestorOnly>
+            <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading…</div>}>
+                <MarketPlacePayment />
+            </Suspense>
+        </InvestorOnly>
     )
 }

--- a/src/app/(dashboard)/marketplace/page.tsx
+++ b/src/app/(dashboard)/marketplace/page.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Marketplace } from '@/app/(dashboard)/marketplace/components/Marketplace'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function Page() {
     return (
-        <div>
-            <Marketplace />
-        </div>
+        <InvestorOnly>
+            <div>
+                <Marketplace />
+            </div>
+        </InvestorOnly>
     )
 }

--- a/src/app/(dashboard)/portfolio/page.tsx
+++ b/src/app/(dashboard)/portfolio/page.tsx
@@ -1,7 +1,10 @@
 import { Portfolio } from '@/app/(dashboard)/portfolio/components/Portfolio'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function Page() {
     return (
-        <Portfolio />
+        <InvestorOnly>
+            <Portfolio />
+        </InvestorOnly>
     )
 }

--- a/src/app/(dashboard)/settings/[slug]/page.tsx
+++ b/src/app/(dashboard)/settings/[slug]/page.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import { useParams, useRouter } from 'next/navigation'
-import { useState, useEffect } from 'react'
-import { useUserStore } from "@/store/userStore"
+import { FundraiserOnly } from '@/components/auth/require-user-type'
 import FundraiserSettings from '@/app/(dashboard)/settings/components/FundraiserSettings'
 
 export default function FundraiserSettingsSlugPage() {
@@ -10,28 +9,12 @@ export default function FundraiserSettingsSlugPage() {
     const router = useRouter()
     const slug = (params?.slug as string) || ''
 
-    const userType = useUserStore((state) => state.userType)
-    const [hasHydrated, setHasHydrated] = useState(false)
-
-    useEffect(() => {
-        setHasHydrated(true)
-    }, [])
-
-    const currentUserType = hasHydrated ? userType : "individual"
-    const isFundraiser = currentUserType === 'fundraiser'
-
-    useEffect(() => {
-        if (hasHydrated && !isFundraiser) {
-            router.replace('/settings')
-        }
-    }, [hasHydrated, isFundraiser, router])
-
-    if (!hasHydrated || !isFundraiser) return null
-
     return (
-        <FundraiserSettings
-            activeSlug={slug}
-            onNavigate={(newSlug) => router.push(`/settings/${newSlug}`)}
-        />
+        <FundraiserOnly>
+            <FundraiserSettings
+                activeSlug={slug}
+                onNavigate={(newSlug) => router.push(`/settings/${newSlug}`)}
+            />
+        </FundraiserOnly>
     )
 }

--- a/src/app/(dashboard)/watchlist/page.tsx
+++ b/src/app/(dashboard)/watchlist/page.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { Watchlist } from '@/app/(dashboard)/watchlist/components/Watchlist'
+import { InvestorOnly } from '@/components/auth/require-user-type'
 
 export default function Page() {
     return (
-        <Watchlist />
+        <InvestorOnly>
+            <Watchlist />
+        </InvestorOnly>
     )
 }

--- a/src/components/auth/require-user-type.tsx
+++ b/src/components/auth/require-user-type.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useEffect, useState, type ReactNode } from "react"
+import { useRouter } from "next/navigation"
+import { useUserStore, type UserType } from "@/store/userStore"
+
+interface RequireUserTypeProps {
+  allow: UserType | UserType[]
+  children: ReactNode
+}
+
+/**
+ * Client-side role gate. Wrong role → `/errors/forbidden` (full 403 page).
+ * Waits for zustand persist hydration so default store values don't flash-allow.
+ */
+export function RequireUserType({ allow, children }: RequireUserTypeProps) {
+  const router = useRouter()
+  const userType = useUserStore((state) => state.userType)
+  const [hasHydrated, setHasHydrated] = useState(false)
+
+  useEffect(() => {
+    const markReady = () => setHasHydrated(true)
+    if (useUserStore.persist.hasHydrated()) {
+      markReady()
+    }
+    return useUserStore.persist.onFinishHydration(markReady)
+  }, [])
+
+  const allowed = Array.isArray(allow) ? allow : [allow]
+  const isAllowed = allowed.includes(userType)
+
+  useEffect(() => {
+    if (hasHydrated && !isAllowed) {
+      router.replace("/errors/forbidden")
+    }
+  }, [hasHydrated, isAllowed, router])
+
+  if (!hasHydrated || !isAllowed) {
+    return null
+  }
+
+  return <>{children}</>
+}
+
+export function FundraiserOnly({ children }: { children: ReactNode }) {
+  return <RequireUserType allow="fundraiser">{children}</RequireUserType>
+}
+
+export function InvestorOnly({ children }: { children: ReactNode }) {
+  return (
+    <RequireUserType allow={["individual", "corporate"]}>{children}</RequireUserType>
+  )
+}

--- a/src/components/documents/molecules/DocumentManagement.tsx
+++ b/src/components/documents/molecules/DocumentManagement.tsx
@@ -1,56 +1,65 @@
 "use client"
 
-import React, { useState } from 'react'
-import { ApplicationStatus } from '@/components/documents/molecules/ApplicationStatus'
-import { DocumentSearchBar } from '@/components/documents/molecules/DocumentSearchBar'
-import { DocumentTable, DocumentItem } from '@/components/documents/molecules/DocumentTable'
+import React, { useMemo, useState } from "react"
+import { ApplicationStatus } from "@/components/documents/molecules/ApplicationStatus"
+import { DocumentSearchBar } from "@/components/documents/molecules/DocumentSearchBar"
+import { DocumentTable, DocumentItem } from "@/components/documents/molecules/DocumentTable"
 
-export default function DocumentManagement() {
-    const [searchQuery, setSearchQuery] = useState('')
+interface DocumentManagementProps {
+  documents: DocumentItem[]
+  isLoading?: boolean
+  latestUpdatedLabel?: string | null
+  onDownload?: (doc: DocumentItem) => void
+}
 
-    const mockDocuments: DocumentItem[] = [
-        { name: "Offering Memorandum.Pdf", size: "2.4 MB", category: "Core", status: "Approved", lastUpdated: "Aug 16, 2025" },
-        { name: "Financial Audit Report 2024.pdf", size: "5.1 MB", category: "Financial", status: "Approved", lastUpdated: "Jun 12, 2025" },
-        { name: "Projected Valuation Model.xlsx", size: "1.2 MB", category: "Analytics", status: "Pending Approval", lastUpdated: "May 12, 2025" },
-        { name: "Environmental Impact Study.pdf", size: "1.4 MB", category: "Analytics", status: "Pending Approval", lastUpdated: "May 12, 2025" },
-        { name: "Offering Memorandum.Pdf", size: "8.4 MB", category: "Regulatory", status: "Revision Requested", lastUpdated: "Feb 08, 2025" },
-    ]
+export default function DocumentManagement({
+  documents,
+  isLoading = false,
+  latestUpdatedLabel = null,
+  onDownload,
+}: DocumentManagementProps) {
+  const [searchQuery, setSearchQuery] = useState("")
 
-    // Filter list matching active search queries inputs
-    const filteredDocs = mockDocuments.filter(doc =>
+  const filteredDocs = useMemo(
+    () =>
+      documents.filter((doc) =>
         doc.name.toLowerCase().includes(searchQuery.toLowerCase())
-    )
+      ),
+    [documents, searchQuery]
+  )
 
-    return (
-        <div className="w-full grid xl:grid-cols-8 gap-4 font-sans items-start">
+  return (
+    <div className="w-full grid xl:grid-cols-8 gap-4 font-sans items-start">
+      <div className="xl:col-span-2 w-full h-full">
+        <ApplicationStatus />
+      </div>
 
-            {/* Left-hand Tracker Column Module component mount */}
-            <div className='xl:col-span-2 w-full h-full'>
-                <ApplicationStatus onRespondToQueries={() => console.log("Routing query dashboard overlay...")} />
+      <div className="xl:col-span-6 w-full min-w-0 bg-white border border-[#F4F5F7] rounded-xl p-4 flex flex-col justify-between">
+        <div>
+          <DocumentSearchBar value={searchQuery} onChange={setSearchQuery} />
+
+          {isLoading ? (
+            <div className="rounded-lg border border-[#EAEAEA] bg-[#FAFAFA] p-6 text-sm text-[#505050]">
+              Loading documents...
             </div>
-
-            <div className="xl:col-span-6 w-full min-w-0 bg-white border border-[#F4F5F7] rounded-xl p-4 flex flex-col justify-between">
-
-                <div>
-                    <DocumentSearchBar
-                        value={searchQuery}
-                        onChange={setSearchQuery}
-                        onHistoryClick={() => console.log("Displaying file event streams logs...")}
-                    />
-                    <DocumentTable
-                        documents={filteredDocs}
-                        onDownload={(doc) => console.log(`Triggering direct asset system fetching stream pipeline for: ${doc.name}`)}
-                    />
-                </div>
-
-                {/* Dynamic Structural Summary Table Info Footer Module metadata line */}
-                <div className="flex items-center justify-between text-xs text-[#999999] pt-4 mt-4">
-                    <span>Total {filteredDocs.length} Documents</span>
-                    <span>Updated 2 Hours Ago</span>
-                </div>
-
+          ) : filteredDocs.length === 0 ? (
+            <div className="rounded-lg border border-[#EAEAEA] bg-[#FAFAFA] p-6 text-sm text-[#505050]">
+              {searchQuery.trim()
+                ? "No documents match your search."
+                : "No documents uploaded yet."}
             </div>
-
+          ) : (
+            <DocumentTable documents={filteredDocs} onDownload={onDownload} />
+          )}
         </div>
-    )
+
+        <div className="flex items-center justify-between text-xs text-[#999999] pt-4 mt-4">
+          <span>Total {filteredDocs.length} Documents</span>
+          <span>
+            {latestUpdatedLabel ? `Updated ${latestUpdatedLabel}` : "—"}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/components/documents/molecules/DocumentTable.tsx
+++ b/src/components/documents/molecules/DocumentTable.tsx
@@ -4,11 +4,13 @@ import React from 'react'
 import { FileText, Download } from 'lucide-react'
 
 export interface DocumentItem {
+    id: number
     name: string
     size: string
     category: string
     status: 'Approved' | 'Pending Approval' | 'Revision Requested'
     lastUpdated: string
+    fileUrl: string
 }
 
 interface DocumentTableProps {
@@ -55,7 +57,7 @@ export function DocumentTable({ documents, onDownload }: DocumentTableProps) {
                         const isDownloadDisabled = !onDownload
 
                         return (
-                            <tr key={`${doc.name}-${doc.category}-${doc.lastUpdated}`} className="hover:bg-[#F9FAFB]/50 transition-colors">
+                            <tr key={doc.id} className="hover:bg-[#F9FAFB]/50 transition-colors">
 
                                 {/* File Details Identity Meta Cell */}
                                 <td className="py-1.5 pr-4 flex items-center gap-3">

--- a/src/components/documents/molecules/UploadDocumentDialog.tsx
+++ b/src/components/documents/molecules/UploadDocumentDialog.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { OnboardingButton } from "@/components/onboarding/molecules/OnboardingButton"
+import type { FundraiserDocumentCategory } from "@/types/fundraiser-documents-api"
+
+const CATEGORIES: FundraiserDocumentCategory[] = [
+  "Core",
+  "Financial",
+  "Analytics",
+  "Regulatory",
+]
+
+interface UploadDocumentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isSubmitting?: boolean
+  onSubmit: (input: {
+    file: File
+    title: string
+    category: FundraiserDocumentCategory
+  }) => void
+}
+
+export function UploadDocumentDialog({
+  open,
+  onOpenChange,
+  isSubmitting = false,
+  onSubmit,
+}: UploadDocumentDialogProps) {
+  const [file, setFile] = useState<File | null>(null)
+  const [title, setTitle] = useState("")
+  const [category, setCategory] = useState<FundraiserDocumentCategory>("Core")
+
+  useEffect(() => {
+    if (!open) {
+      setFile(null)
+      setTitle("")
+      setCategory("Core")
+    }
+  }, [open])
+
+  const handleFileChange = (next: File | null) => {
+    setFile(next)
+    if (next && !title.trim()) {
+      setTitle(next.name)
+    }
+  }
+
+  const canSubmit = Boolean(file && title.trim() && !isSubmitting)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Upload New Document</DialogTitle>
+          <DialogDescription>
+            Upload a PDF, Word, Excel, CSV, or image file for your offering.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <label className="block space-y-1.5 text-sm">
+            <span className="text-[#505050]">File</span>
+            <input
+              type="file"
+              accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,image/*"
+              className="block w-full text-sm text-[#1B1B1B] file:mr-3 file:rounded-md file:border-0 file:bg-[#EFF4E4] file:px-3 file:py-2 file:text-sm file:font-medium"
+              onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
+            />
+          </label>
+
+          <label className="block space-y-1.5 text-sm">
+            <span className="text-[#505050]">Document title</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-lg border border-[#EAEAEA] bg-white px-3 py-2 text-sm text-[#1B1B1B] outline-none focus:border-[#B9C65B]"
+              placeholder="Offering Memorandum.pdf"
+            />
+          </label>
+
+          <label className="block space-y-1.5 text-sm">
+            <span className="text-[#505050]">Category</span>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value as FundraiserDocumentCategory)}
+              className="w-full rounded-lg border border-[#EAEAEA] bg-white px-3 py-2 text-sm text-[#1B1B1B] outline-none focus:border-[#B9C65B]"
+            >
+              {CATEGORIES.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <OnboardingButton
+            label="Cancel"
+            variant="plain"
+            className="my-0"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          />
+          <OnboardingButton
+            label={isSubmitting ? "Uploading..." : "Upload"}
+            className="my-0"
+            disabled={!canSubmit}
+            onClick={() => {
+              if (!file || !title.trim()) return
+              onSubmit({ file, title: title.trim(), category })
+            }}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const CACHE_KEY_FUNDRAISER_QII = ["fundraiser-qii"] as const;
 export const CACHE_KEY_FUNDRAISER_INVESTOR_MESSAGES = ["fundraiser-investor-messages"] as const;
 export const CACHE_KEY_FUNDRAISER_INVESTOR_ANALYTICS = ["fundraiser-investor-analytics"] as const;
 export const CACHE_KEY_FUNDRAISER_ANALYTICS = ["fundraiser-analytics"] as const;
+export const CACHE_KEY_FUNDRAISER_DOCUMENTS = ["fundraiser-documents"] as const;
 export const CACHE_KEY_WALLET_TRANSACTIONS = ["wallet-transactions"] as const;
 export const CACHE_KEY_PAYMENT_METHODS = ["payment-methods"] as const;
 export const CACHE_KEY_WATCHLIST = ["watchlist"] as const;

--- a/src/hooks/use-fundraiser-documents.ts
+++ b/src/hooks/use-fundraiser-documents.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CACHE_KEY_FUNDRAISER_DOCUMENTS } from "@/constants";
+import fundraiserDocumentsService from "@/services/fundraiserDocumentsService";
+import type { UploadFundraiserDocumentInput } from "@/types/fundraiser-documents-api";
+import { showApiErrorToast } from "@/lib/error-feedback";
+import { toast } from "sonner";
+
+export function useFundraiserDocuments(enabled = true) {
+  return useQuery({
+    queryKey: CACHE_KEY_FUNDRAISER_DOCUMENTS,
+    queryFn: () => fundraiserDocumentsService.listDocuments(),
+    enabled,
+  });
+}
+
+export function useUploadFundraiserDocument() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: UploadFundraiserDocumentInput) =>
+      fundraiserDocumentsService.uploadDocument(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CACHE_KEY_FUNDRAISER_DOCUMENTS });
+      toast.success("Document uploaded");
+    },
+    onError: (error) => {
+      showApiErrorToast(error, "Unable to upload document.");
+    },
+  });
+}

--- a/src/services/fileUploadService.ts
+++ b/src/services/fileUploadService.ts
@@ -1,0 +1,33 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type { FileUploadInput, FileUploadResponse } from "@/types/file-upload-api";
+import { toApiError } from "@/lib/api-error";
+
+const BASE = "/api/files/upload";
+
+/**
+ * Shared Cloudinary-backed upload client.
+ * Use from documents, onboarding, and other flows that need binary upload.
+ */
+async function upload(input: FileUploadInput): Promise<FileUploadResponse> {
+  try {
+    const formData = new FormData();
+    formData.append("file", input.file);
+    if (input.folder) {
+      formData.append("folder", input.folder);
+    }
+
+    const res = await request.post<ApiResponse<FileUploadResponse>>(BASE, formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const fileUploadService = {
+  upload,
+};
+
+export default fileUploadService;

--- a/src/services/fundraiserDocumentsService.ts
+++ b/src/services/fundraiserDocumentsService.ts
@@ -1,0 +1,46 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type {
+  FundraiserDocument,
+  FundraiserDocumentsResponse,
+  UploadFundraiserDocumentInput,
+} from "@/types/fundraiser-documents-api";
+import { toApiError } from "@/lib/api-error";
+
+const BASE = "/api/fundraisers/me/documents";
+
+async function listDocuments(): Promise<FundraiserDocumentsResponse> {
+  try {
+    const res = await request.get<ApiResponse<FundraiserDocumentsResponse>>(BASE);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function uploadDocument(
+  input: UploadFundraiserDocumentInput
+): Promise<FundraiserDocument> {
+  try {
+    const formData = new FormData();
+    formData.append("file", input.file);
+    formData.append("category", input.category);
+    if (input.title?.trim()) {
+      formData.append("title", input.title.trim());
+    }
+
+    const res = await request.post<ApiResponse<FundraiserDocument>>(BASE, formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const fundraiserDocumentsService = {
+  listDocuments,
+  uploadDocument,
+};
+
+export default fundraiserDocumentsService;

--- a/src/types/file-upload-api.ts
+++ b/src/types/file-upload-api.ts
@@ -1,0 +1,13 @@
+export interface FileUploadResponse {
+  url: string;
+  publicId: string;
+  bytes: number;
+  contentType: string;
+  originalFileName: string;
+  resourceType: string;
+}
+
+export interface FileUploadInput {
+  file: File;
+  folder?: string;
+}

--- a/src/types/fundraiser-documents-api.ts
+++ b/src/types/fundraiser-documents-api.ts
@@ -1,0 +1,33 @@
+export type FundraiserDocumentCategory =
+  | "Core"
+  | "Financial"
+  | "Analytics"
+  | "Regulatory";
+
+export type FundraiserDocumentStatus =
+  | "Approved"
+  | "Pending Approval"
+  | "Revision Requested";
+
+export interface FundraiserDocument {
+  id: number;
+  title: string;
+  category: FundraiserDocumentCategory | string;
+  status: FundraiserDocumentStatus | string;
+  fileUrl: string;
+  fileSizeBytes: number;
+  contentType: string;
+  lastUpdatedAt: string;
+}
+
+export interface FundraiserDocumentsResponse {
+  offeringId: number | null;
+  offeringSlug: string | null;
+  items: FundraiserDocument[];
+}
+
+export interface UploadFundraiserDocumentInput {
+  file: File;
+  title?: string;
+  category: FundraiserDocumentCategory;
+}


### PR DESCRIPTION
## Summary
- Add reusable `fileUploadService` and wire `/documents` to fundraiser documents list/upload APIs
- Enable upload dialog with title/category; download opens Cloudinary file URLs
- Gate role-exclusive sidebar routes with `FundraiserOnly` / `InvestorOnly` → `/errors/forbidden`

Closes #213.

## Test plan
- [x] Sign in as fundraiser and open `/documents`; confirm seeded docs load
- [x] Upload a PDF and confirm it appears as Pending Approval
- [x] As investor, open `/campaigns` / `/documents` and land on 403
- [x] As fundraiser, open `/portfolio` / `/marketplace` and land on 403
- [x] Pair with API PR for Cloudinary end-to-end upload


Made with [Cursor](https://cursor.com)