### PR TITLE
Wire fundraiser settings to profile and notification APIs

### DIFF
--- a/src/app/(dashboard)/settings/components/FundraiserSettings.tsx
+++ b/src/app/(dashboard)/settings/components/FundraiserSettings.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
     User, Bell, Shield, Wallet, ChevronRight,
     ArrowLeft,
 } from 'lucide-react';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton';
-import { CompanyProfile, MOCK_COMPANY_PROFILE } from '@/components/settings/organisms/fundraiser/CompanyProfile';
+import { CompanyProfile } from '@/components/settings/organisms/fundraiser/CompanyProfile';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { TeamManagement } from '@/components/settings/organisms/fundraiser/TeamManagement';
 import { ContactInformation } from '@/components/settings/organisms/fundraiser/ContactInformation';
@@ -18,6 +18,8 @@ import { SecurityAnd2fa } from '@/components/settings/organisms/fundraiser/Secur
 import { BankAccount } from '@/components/settings/organisms/fundraiser/BankAccounts';
 import { DisbursementSchedule } from '@/components/settings/organisms/fundraiser/DisbursementSchedule';
 import { TaxDocumentation } from '@/components/settings/organisms/fundraiser/TaxDocumentation';
+import { useFundraiserSettingsProfile } from '@/hooks/use-fundraiser-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
 
 interface FundraiserSettingsProps {
     activeSlug: string;
@@ -68,6 +70,13 @@ const SETTINGS_GROUPS = [
 ];
 
 export default function FundraiserSettings({ activeSlug, onNavigate }: FundraiserSettingsProps) {
+    const { data: profile, isError, error } = useFundraiserSettingsProfile();
+
+    useEffect(() => {
+        if (isError) {
+            showApiErrorToast(error, 'Unable to load settings profile.');
+        }
+    }, [isError, error]);
 
     const activePageName = useMemo(() => {
         if (!activeSlug) return '';
@@ -79,6 +88,10 @@ export default function FundraiserSettings({ activeSlug, onNavigate }: Fundraise
     }, [activeSlug]);
 
     const handleBack = () => onNavigate('');
+
+    const brandName = profile?.companyName?.trim() || 'Your organization';
+    const brandLocation = profile?.locationLabel?.trim() || 'Location not set';
+    const brandFallback = profile?.companyAvatarFallback?.trim() || 'FR';
 
     const renderSubView = () => {
         switch (activeSlug) {
@@ -150,29 +163,30 @@ export default function FundraiserSettings({ activeSlug, onNavigate }: Fundraise
                     </div>
                     <div className="w-full grid lg:grid-cols-11 gap-6 font-sans items-start">
 
-                        {/* Left Corporate Brand Panel Block Card */}
                         <div className="lg:col-span-3 w-full shrink-0 flex flex-col items-center">
                             <div className=' bg-white border border-[#F4F5F7] rounded-md px-4 py-6 flex flex-col items-center w-full'>
                                 <Avatar className="mb-4 h-14 w-14 border border-[#EAEAEA] cursor-pointer">
-                                    <AvatarImage src={MOCK_COMPANY_PROFILE.companyAvatarURL} alt="Company shorthand" />
-                                    <AvatarFallback>{MOCK_COMPANY_PROFILE.companyAvatarFallback}</AvatarFallback>
+                                    {profile?.companyAvatarUrl ? (
+                                        <AvatarImage src={profile.companyAvatarUrl} alt="Company shorthand" />
+                                    ) : null}
+                                    <AvatarFallback>{brandFallback}</AvatarFallback>
                                 </Avatar>
 
                                 <h4 className="text-[18px] text-[#1B1B1B] text-center mb-2" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
-                                    {MOCK_COMPANY_PROFILE.companyName}
+                                    {brandName}
                                 </h4>
                                 <p className="text-[12px] text-[#858585] text-center mb-4">
-                                    {MOCK_COMPANY_PROFILE.locationLabel}
+                                    {brandLocation}
                                 </p>
 
                                 <OnboardingButton
                                     label="Edit Branding"
                                     variant="plain"
                                     className="w-full text-[14px] bg-[#F9FAFB] text-[#1B1B1B] border-none"
+                                    onClick={() => onNavigate('company-profile')}
                                 />
                             </div>
 
-                            {/* Premium Badge Frame segment */}
                             <div className="w-full mt-4 bg-[#021310] text-white rounded-md p-4 relative overflow-hidden">
                                 <span className="text-[12px] tracking-wide text-[#B9C65B]">Membership</span>
                                 <h5 className="text-[18px] text-[#F4F5F7] font-medium mt-4">Premium Fundraiser</h5>
@@ -184,13 +198,11 @@ export default function FundraiserSettings({ activeSlug, onNavigate }: Fundraise
                             </div>
                         </div>
 
-                        {/* Right Group Stack Workspace Columns Layout Menu Panel */}
                         <div className="lg:col-span-8 w-full space-y-4">
                             {SETTINGS_GROUPS.map((group, gIdx) => {
                                 const GroupIcon = group.icon;
                                 return (
                                     <div key={gIdx} className="bg-white border border-[#EAEAEA] rounded-md overflow-hidden">
-                                        {/* Inner Heading Anchor Panel */}
                                         <div className="p-4 bg-[#F4F5F7] flex items-center gap-3">
                                             <div className='p-2 rounded-md bg-white'>
                                                 <GroupIcon className="w-4 h-4 text-[#B9C65B]" />
@@ -200,7 +212,6 @@ export default function FundraiserSettings({ activeSlug, onNavigate }: Fundraise
                                             </h4>
                                         </div>
 
-                                        {/* Settings Target Item Lists */}
                                         <div className="divide-y divide-[#EAEAEA] px-4">
                                             {group.items.map((item, iIdx) => (
                                                 <button

--- a/src/components/settings/organisms/fundraiser/CompanyProfile.tsx
+++ b/src/components/settings/organisms/fundraiser/CompanyProfile.tsx
@@ -1,242 +1,294 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { MapPin, Globe, Mail } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { OnboardingInput } from '@/components/onboarding/molecules/OnboardingInput';
+import {
+  useFundraiserSettingsProfile,
+  useUpdateFundraiserSettingsProfile,
+} from '@/hooks/use-fundraiser-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
+import type { FundraiserSettingsProfile } from '@/types/settings';
 
-export interface CompanyProfileData {
-    companyName: string;
-    registrationNumber: string;
-    bio: string;
-    website: string;
-    publicEmail: string;
-    headquarters: string;
-    completionPercentage: number;
-    locationLabel: string;
-    companyAvatarURL: string;
-    companyAvatarFallback: string;
-
-}
-
-export const MOCK_COMPANY_PROFILE: CompanyProfileData = {
-    companyName: 'Skyhigh Technologies',
-    registrationNumber: 'RC - 12345678',
-    bio: 'Skyhigh Technologies is an innovative company dedicated to creating advanced prosthetic solutions. Based in the heart of Silicon Valley, we focus on enhancing the quality of life for individuals with limb loss through cutting-edge technology and personalized designs.',
-    website: 'https://Skyhightechnologies.com',
-    publicEmail: 'contact@skyhightech.com',
-    headquarters: '123 Business way, Victoria Island, Lagos, Nigeria',
-    completionPercentage: 85,
-    locationLabel: 'Lagos, Nigeria',
-    companyAvatarURL: '/dashboard/plantIQ.png',
-    companyAvatarFallback: 'ST'
+type CompanyFormState = {
+  companyName: string;
+  registrationNumber: string;
+  bio: string;
+  website: string;
+  publicEmail: string;
+  headquarters: string;
 };
 
-const ONLINE_PRESENCE_CHANNELS = [
-    {
-        key: 'website',
-        label: 'Website',
-        icon: Globe,
-        value: MOCK_COMPANY_PROFILE.website,
-        onEdit: () => console.log('Edit website triggered'),
-    },
-    {
-        key: 'email',
-        label: 'Public email',
-        icon: Mail,
-        value: MOCK_COMPANY_PROFILE.publicEmail,
-        onEdit: () => console.log('Edit public email triggered'),
-    },
-] as const;
+const EMPTY_FORM: CompanyFormState = {
+  companyName: '',
+  registrationNumber: '',
+  bio: '',
+  website: '',
+  publicEmail: '',
+  headquarters: '',
+};
 
-interface CompanyProfileProps {
-    onBack: () => void;
-    onSave?: (updatedData: Partial<CompanyProfileData>) => void;
+function mapProfileToForm(profile: FundraiserSettingsProfile): CompanyFormState {
+  return {
+    companyName: profile.companyName ?? '',
+    registrationNumber: profile.registrationNumber ?? '',
+    bio: profile.bio ?? '',
+    website: profile.website ?? '',
+    publicEmail: profile.publicEmail ?? '',
+    headquarters: profile.headquarters ?? '',
+  };
 }
 
-export function CompanyProfile({ onBack, onSave }: CompanyProfileProps) {
+interface CompanyProfileProps {
+  onBack: () => void;
+}
 
-    const [form, setForm] = useState({
-        companyName: MOCK_COMPANY_PROFILE.companyName,
-        registrationNumber: MOCK_COMPANY_PROFILE.registrationNumber,
-        bio: MOCK_COMPANY_PROFILE.bio
-    });
+export function CompanyProfile({ onBack }: CompanyProfileProps) {
+  const { data: profile, isLoading, isError, error } = useFundraiserSettingsProfile();
+  const updateProfile = useUpdateFundraiserSettingsProfile();
+  const [form, setForm] = useState<CompanyFormState>(EMPTY_FORM);
 
-    const handleInputChange = (field: keyof typeof form, value: string) => {
-        setForm(prev => ({ ...prev, [field]: value }));
-    };
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, 'Unable to load company profile.');
+    }
+  }, [isError, error]);
 
-    const handleSubmit = () => {
-        if (onSave) {
-            onSave(form);
-        } else {
-            console.log('API Payload ready for transport:', form);
-        }
-    };
+  useEffect(() => {
+    if (profile) {
+      setForm(mapProfileToForm(profile));
+    }
+  }, [profile]);
 
-    return (
-        <div className="w-full font-sans space-y-6">
+  const handleInputChange = (field: keyof CompanyFormState, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
 
-            {/* Banner Header Block Frame */}
-            <div className="w-full bg-white border border-[#F4F5F7] rounded-xl overflow-hidden">
-                <div className="w-full h-27 bg-[#0EA5E9] relative" />
-                <div className="px-6 pb-6 pt-0 flex flex-col sm:flex-row items-start sm:items-center gap-4 relative">
+  const handleDiscard = () => {
+    if (profile) {
+      setForm(mapProfileToForm(profile));
+    }
+    onBack();
+  };
 
-                    <Avatar className="mb-4 h-25 w-25 cursor-pointer mt-[-40px]">
-                        <AvatarImage src={MOCK_COMPANY_PROFILE.companyAvatarURL} alt="Company shorthand" />
-                        <AvatarFallback>{MOCK_COMPANY_PROFILE.companyAvatarFallback}</AvatarFallback>
-                    </Avatar>
+  const handleSubmit = () => {
+    if (!form.companyName.trim()) {
+      toast.error('Company name is required.');
+      return;
+    }
 
-                    <div className="mt-2 lg:-mt-2">
-                        <h2 className="text-[24px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
-                            {form.companyName || 'Organization Name'}
-                        </h2>
-                        <p className="text-[16px] text-[#858585]">
-                            Fundraising Organization – {MOCK_COMPANY_PROFILE.locationLabel}
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            {/* Layout Grid Panels */}
-            <div className="grid lg:grid-cols-12 gap-6 items-start">
-
-                {/* Left Side: Editable form fields */}
-                <div className="lg:col-span-8 space-y-6">
-                    <div className="bg-white border border-[#F4F5F7] rounded-xl px-4 pt-4">
-                        <h3 className="text-[16px] text-[#1B1B1B] mb-4" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
-                            General Information
-                        </h3>
-
-                        <div className="grid sm:grid-cols-2 gap-4">
-
-                            <OnboardingInput
-                                label='Company Name'
-                                type="text"
-                                value={form.companyName}
-                                onChange={(e) => handleInputChange('companyName', e.target.value)}
-                                inputAreaStyle='text-[16px] text-[#505050] focus:ring-1'
-                                labelStyle='text-[#505050]'
-                            />
-
-                            <OnboardingInput
-                                label='Registration Number'
-                                type="text"
-                                value={form.registrationNumber}
-                                onChange={(e) => handleInputChange('registrationNumber', e.target.value)}
-                                inputAreaStyle='text-[16px] text-[#505050] focus:ring-1'
-                                labelStyle='text-[#505050]'
-                            />
-
-                        </div>
-
-                        <OnboardingInput
-                            label='Company Bio'
-                            type="textarea"
-                            value={form.bio}
-                            onChange={(e) => handleInputChange('bio', e.target.value)}
-                            inputAreaStyle='text-[16px] text-[#505050] focus:ring-1'
-                            labelStyle='text-[#505050]'
-                            className='pb-0'
-                        />
-
-                    </div>
-
-                    {/* Online Presence (Static Read-Only for Now) */}
-                    <div className="bg-white border border-[#F4F5F7] rounded-xl p-5 space-y-4">
-                        <h3 className="text-[16px] text-[#1B1B1B] mb-4" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
-                            Online Presence
-                        </h3>
-                        <div className="space-y-3">
-                            {ONLINE_PRESENCE_CHANNELS.map(({ key, label, icon: Icon, value, onEdit }) => (
-                                <div
-                                    key={key}
-                                    className="flex items-center justify-between p-3.5 bg-[#F4F5F7] rounded-lg border border-transparent"
-                                >
-                                    <div className="flex items-center gap-3">
-                                        <Icon className="w-5 h-5 text-[#1F1F1F]" />
-                                        <div>
-                                            <span className="block text-[12px] text-[#A8A8A8]">{label}</span>
-                                            <span className="text-sm text-[#1B1B1B] font-medium">{value}</span>
-                                        </div>
-                                    </div>
-                                    <button
-                                        type="button"
-                                        onClick={onEdit}
-                                        className="text-[#B9C65B] text-[14px] font-medium cursor-pointer hover:text-[#A4B04E] transition-colors"
-                                    >
-                                        Edit
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                </div>
-
-                {/* Right Side Sidebar: Data Driven Info cards */}
-                <div className="lg:col-span-4 space-y-4">
-                    <div className="bg-white border border-[#F4F5F7] rounded-xl p-5 space-y-4">
-                        <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
-                            Location
-                        </h3>
-                        <div className="flex items-start gap-3">
-                            <MapPin className="w-5 h-5 text-[#858585]" />
-                            <div>
-                                <h4 className="text-[16px] font-medium text-[#505050]">Headquarters</h4>
-                                <p className="text-[14px] text-[#858585] mt-1 leading-relaxed">
-                                    {MOCK_COMPANY_PROFILE.headquarters}
-                                </p>
-                            </div>
-                        </div>
-
-                        <OnboardingButton
-                            label="Update Location"
-                            variant="plain"
-                            className="w-full text-[14px] bg-[#F9FAFB] text-[#1B1B1B] border-none"
-                        />
-                    </div>
-
-                    <div className="bg-[#EDF1D6] border border-[#B9C65B] rounded-xl px-4 py-6 space-y-3">
-                        <h4 className="text-[16px] text-[#7D8A26]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
-                            Profile Strength
-                        </h4>
-
-                        <p className='text-[14px] text-[#858585]'>
-                            Complete your profile to increase trust with potential investors
-                        </p>
-                        <div className="space-y-2 pt-3">
-                            <div className="w-full h-2 bg-white rounded-full overflow-hidden">
-                                <div
-                                    className="h-full bg-[#7D8A26] rounded-full transition-all duration-500"
-                                    style={{ width: `${MOCK_COMPANY_PROFILE.completionPercentage}%` }}
-                                />
-                            </div>
-                            <span className="block text-[12px] font-bold text-[#858585]">
-                                {MOCK_COMPANY_PROFILE.completionPercentage}% Completed
-                            </span>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-
-            {/* Bottom Form Actions Control Footnotes */}
-            <div className="w-full flex  flex-col lg:flex-row justify-end items-center gap-3 pt-4">
-                <OnboardingButton
-                    label="Discard Changes"
-                    variant="plain"
-                    className="lg:max-w-[271px] border-[#EAEAEA]"
-                    onClick={onBack}
-                />
-                <OnboardingButton
-                    label="Save Profile"
-                    className="lg:max-w-[271px]"
-                    onClick={handleSubmit}
-                />
-            </div>
-
-        </div>
+    updateProfile.mutate(
+      {
+        companyName: form.companyName.trim(),
+        registrationNumber: form.registrationNumber.trim() || null,
+        bio: form.bio.trim() || null,
+        website: form.website.trim() || null,
+        publicEmail: form.publicEmail.trim() || null,
+        headquarters: form.headquarters.trim() || null,
+        contact: profile
+          ? {
+              fullName: profile.contact.fullName,
+              emailAddress: profile.contact.emailAddress,
+              phoneNumber: profile.contact.phoneNumber,
+            }
+          : null,
+      },
+      {
+        onSuccess: () => {
+          toast.success('Company profile updated');
+        },
+        onError: (saveError) => {
+          showApiErrorToast(saveError, 'Unable to update company profile.');
+        },
+      },
     );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Loading company profile...
+        </p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Unable to load company profile.
+        </p>
+      </div>
+    );
+  }
+
+  const locationLabel = profile.locationLabel || 'Location not set';
+  const avatarFallback = profile.companyAvatarFallback || 'FR';
+  const completionPercentage = profile.completionPercentage ?? 0;
+
+  return (
+    <div className="w-full font-sans space-y-6">
+      <div className="w-full bg-white border border-[#F4F5F7] rounded-xl overflow-hidden">
+        <div className="w-full h-27 bg-[#0EA5E9] relative" />
+        <div className="px-6 pb-6 pt-0 flex flex-col sm:flex-row items-start sm:items-center gap-4 relative">
+          <Avatar className="mb-4 h-25 w-25 cursor-pointer mt-[-40px]">
+            {profile.companyAvatarUrl ? (
+              <AvatarImage src={profile.companyAvatarUrl} alt="Company shorthand" />
+            ) : null}
+            <AvatarFallback>{avatarFallback}</AvatarFallback>
+          </Avatar>
+
+          <div className="mt-2 lg:-mt-2">
+            <h2 className="text-[24px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
+              {form.companyName || 'Organization Name'}
+            </h2>
+            <p className="text-[16px] text-[#858585]">
+              Fundraising Organization – {locationLabel}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-12 gap-6 items-start">
+        <div className="lg:col-span-8 space-y-6">
+          <div className="bg-white border border-[#F4F5F7] rounded-xl px-4 pt-4">
+            <h3 className="text-[16px] text-[#1B1B1B] mb-4" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
+              General Information
+            </h3>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <OnboardingInput
+                label="Company Name"
+                type="text"
+                value={form.companyName}
+                onChange={(e) => handleInputChange('companyName', e.target.value)}
+                inputAreaStyle="text-[16px] text-[#505050] focus:ring-1"
+                labelStyle="text-[#505050]"
+              />
+
+              <OnboardingInput
+                label="Registration Number"
+                type="text"
+                value={form.registrationNumber}
+                onChange={(e) => handleInputChange('registrationNumber', e.target.value)}
+                inputAreaStyle="text-[16px] text-[#505050] focus:ring-1"
+                labelStyle="text-[#505050]"
+              />
+            </div>
+
+            <OnboardingInput
+              label="Company Bio"
+              type="textarea"
+              value={form.bio}
+              onChange={(e) => handleInputChange('bio', e.target.value)}
+              inputAreaStyle="text-[16px] text-[#505050] focus:ring-1"
+              labelStyle="text-[#505050]"
+              className="pb-0"
+            />
+          </div>
+
+          <div className="bg-white border border-[#F4F5F7] rounded-xl p-5 space-y-4">
+            <h3 className="text-[16px] text-[#1B1B1B] mb-4" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
+              Online Presence
+            </h3>
+            <div className="space-y-3">
+              <div className="flex items-start gap-3 p-3.5 bg-[#F4F5F7] rounded-lg">
+                <Globe className="w-5 h-5 text-[#1F1F1F] mt-6 shrink-0" />
+                <div className="flex-1">
+                  <OnboardingInput
+                    label="Website"
+                    type="text"
+                    value={form.website}
+                    onChange={(e) => handleInputChange('website', e.target.value)}
+                    inputAreaStyle="text-[16px] text-[#505050] focus:ring-1 bg-white"
+                    labelStyle="text-[#A8A8A8]"
+                    className="pb-0"
+                  />
+                </div>
+              </div>
+              <div className="flex items-start gap-3 p-3.5 bg-[#F4F5F7] rounded-lg">
+                <Mail className="w-5 h-5 text-[#1F1F1F] mt-6 shrink-0" />
+                <div className="flex-1">
+                  <OnboardingInput
+                    label="Public email"
+                    type="email"
+                    value={form.publicEmail}
+                    onChange={(e) => handleInputChange('publicEmail', e.target.value)}
+                    inputAreaStyle="text-[16px] text-[#505050] focus:ring-1 bg-white"
+                    labelStyle="text-[#A8A8A8]"
+                    className="pb-0"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="lg:col-span-4 space-y-4">
+          <div className="bg-white border border-[#F4F5F7] rounded-xl p-5 space-y-4">
+            <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
+              Location
+            </h3>
+            <div className="flex items-start gap-3">
+              <MapPin className="w-5 h-5 text-[#858585] shrink-0 mt-1" />
+              <div className="flex-1">
+                <OnboardingInput
+                  label="Headquarters"
+                  type="textarea"
+                  value={form.headquarters}
+                  onChange={(e) => handleInputChange('headquarters', e.target.value)}
+                  inputAreaStyle="text-[14px] text-[#858585] focus:ring-1"
+                  labelStyle="text-[#505050]"
+                  className="pb-0"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-[#EDF1D6] border border-[#B9C65B] rounded-xl px-4 py-6 space-y-3">
+            <h4 className="text-[16px] text-[#7D8A26]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
+              Profile Strength
+            </h4>
+
+            <p className="text-[14px] text-[#858585]">
+              Complete your profile to increase trust with potential investors
+            </p>
+            <div className="space-y-2 pt-3">
+              <div className="w-full h-2 bg-white rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-[#7D8A26] rounded-full transition-all duration-500"
+                  style={{ width: `${completionPercentage}%` }}
+                />
+              </div>
+              <span className="block text-[12px] font-bold text-[#858585]">
+                {completionPercentage}% Completed
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="w-full flex flex-col lg:flex-row justify-end items-center gap-3 pt-4">
+        <OnboardingButton
+          label="Discard Changes"
+          variant="plain"
+          className="lg:max-w-[271px] border-[#EAEAEA]"
+          onClick={handleDiscard}
+          disabled={updateProfile.isPending}
+        />
+        <OnboardingButton
+          label="Save Profile"
+          className="lg:max-w-[271px]"
+          onClick={handleSubmit}
+          loading={updateProfile.isPending}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/components/settings/organisms/fundraiser/ContactInformation.tsx
+++ b/src/components/settings/organisms/fundraiser/ContactInformation.tsx
@@ -1,161 +1,226 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Globe, MessageCircle } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton';
 import { OnboardingInput } from '@/components/onboarding/molecules/OnboardingInput';
+import {
+  useFundraiserSettingsProfile,
+  useUpdateFundraiserSettingsProfile,
+} from '@/hooks/use-fundraiser-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
+import type { FundraiserSettingsProfile } from '@/types/settings';
 
-export interface ContactInfoData {
-    fullName: string;
-    emailAddress: string;
-    phoneNumber: string;
-    isWhatsAppConnected: boolean;
-    hasPublicHelpDesk: boolean;
-}
+type ContactFormState = {
+  fullName: string;
+  emailAddress: string;
+  phoneNumber: string;
+};
 
-const MOCK_CONTACT_INFO: ContactInfoData = {
-    fullName: 'John Doe',
-    emailAddress: 'doe@skyhightech.com',
-    phoneNumber: '+234 801 234 5678',
-    isWhatsAppConnected: false,
-    hasPublicHelpDesk: true
+const EMPTY_FORM: ContactFormState = {
+  fullName: '',
+  emailAddress: '',
+  phoneNumber: '',
 };
 
 const CONTACT_FIELDS = [
-    { key: 'fullName', label: 'Full Name', type: 'text' },
-    { key: 'emailAddress', label: 'Email Address', type: 'email' },
-    { key: 'phoneNumber', label: 'Phone Number', type: 'text' },
+  { key: 'fullName', label: 'Full Name', type: 'text' },
+  { key: 'emailAddress', label: 'Email Address', type: 'email' },
+  { key: 'phoneNumber', label: 'Phone Number', type: 'text' },
 ] as const;
 
-const SUPPORT_CHANNELS = [
-    {
-        id: 'whatsapp',
-        label: 'WhatsApp Support',
-        icon: MessageCircle,
-        isConnected: MOCK_CONTACT_INFO.isWhatsAppConnected,
-        onClick: () => console.log('Triggering WhatsApp integration configuration hook...'),
-    },
-    {
-        id: 'helpdesk',
-        label: 'Public Help Desk',
-        icon: Globe,
-        isConnected: MOCK_CONTACT_INFO.hasPublicHelpDesk,
-        onClick: () => console.log('Triggering Help Desk settings panel mapping...'),
-    },
-] as const;
-
-
-interface ContactInformationProps {
-    onBack: () => void;
-    onSave?: (updatedData: Partial<ContactInfoData>) => void;
+function mapProfileToForm(profile: FundraiserSettingsProfile): ContactFormState {
+  return {
+    fullName: profile.contact.fullName ?? '',
+    emailAddress: profile.contact.emailAddress ?? '',
+    phoneNumber: profile.contact.phoneNumber ?? '',
+  };
 }
 
-export function ContactInformation({ onBack, onSave }: ContactInformationProps) {
+interface ContactInformationProps {
+  onBack: () => void;
+}
 
-    const [form, setForm] = useState({
-        fullName: MOCK_CONTACT_INFO.fullName,
-        emailAddress: MOCK_CONTACT_INFO.emailAddress,
-        phoneNumber: MOCK_CONTACT_INFO.phoneNumber
-    });
+export function ContactInformation({ onBack }: ContactInformationProps) {
+  const { data: profile, isLoading, isError, error } = useFundraiserSettingsProfile();
+  const updateProfile = useUpdateFundraiserSettingsProfile();
+  const [form, setForm] = useState<ContactFormState>(EMPTY_FORM);
 
-    const handleInputChange = (field: keyof typeof form, value: string) => {
-        setForm(prev => ({ ...prev, [field]: value }));
-    };
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, 'Unable to load contact information.');
+    }
+  }, [isError, error]);
 
-    const handleSubmit = () => {
-        if (onSave) {
-            onSave(form);
-        } else {
-            console.log('API Contact Payload ready for transport:', form);
-        }
-    };
+  useEffect(() => {
+    if (profile) {
+      setForm(mapProfileToForm(profile));
+    }
+  }, [profile]);
 
-    return (
-        <div className="w-full font-sans space-y-6">
+  const handleInputChange = (field: keyof ContactFormState, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
 
-            {/* Header Description Title */}
-            <div>
-                <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
-                    Contact Information
-                </h2>
-                <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
-                    Manage how we and your investors can reach you.
-                </p>
-            </div>
+  const handleDiscard = () => {
+    if (profile) {
+      setForm(mapProfileToForm(profile));
+    }
+    onBack();
+  };
 
-            {/* Main Content Workspace Layout Matrix Grid */}
-            <div className="grid lg:grid-cols-12 gap-6 items-start">
+  const handleSubmit = () => {
+    if (!profile) {
+      return;
+    }
 
-                {/* Left Side Sheet: Primary Contact Details Fields */}
-                <div className="lg:col-span-7 bg-white border border-[#F4F5F7] rounded-xl p-6 space-y-4">
-                    <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
-                        Primary Contact
-                    </h3>
+    const companyName = profile.companyName?.trim();
+    if (!companyName) {
+      toast.error('Set a company name in Company Profile before saving contact details.');
+      return;
+    }
 
-                    <div className="space-y-1">
-
-                        {CONTACT_FIELDS.map(({ key, label, type }) => (
-                            <OnboardingInput
-                                key={key}
-                                label={label}
-                                type={type}
-                                value={form[key]}
-                                onChange={(e) => handleInputChange(key, e.target.value)}
-                                inputAreaStyle="text-[16px] text-[#505050] focus:ring-1"
-                                labelStyle="text-[#505050]"
-                            />
-                        ))}
-
-                    </div>
-                </div>
-
-                {/* Right Side Sheet: Integration Support Channels Panel */}
-                <div className="lg:col-span-5 bg-white border border-[#F4F5F7] rounded-xl p-6 space-y-4">
-                    <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
-                        Support Channels
-                    </h3>
-
-                    <div className="space-y-3">
-
-                        {SUPPORT_CHANNELS.map(({ label, icon: Icon, isConnected, onClick }) => (
-                            <div
-                                key={label}
-                                className="flex items-center justify-between p-3.5 bg-[#F4F5F7] rounded-lg border border-transparent"
-                            >
-                                <div className="flex items-center gap-3">
-                                    <Icon className="w-4.5 h-4.5 text-[#858585]" />
-                                    <span className="text-sm text-[#595959] font-medium">{label}</span>
-                                </div>
-                                <button
-                                    type="button"
-                                    className='text-[#B9C65B] text-[14px] font-medium cursor-pointer'
-                                    onClick={onClick}
-                                >
-                                    {isConnected ? 'Manage' : 'Connect'}
-                                </button>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-
-            </div>
-
-            {/* Bottom Form Action Commands Row Footer Component Strip */}
-            <div className="w-full flex  flex-col lg:flex-row justify-end items-center gap-3 pt-4">
-                <OnboardingButton
-                    label="Discard Changes"
-                    variant="plain"
-                    className="lg:max-w-[271px] border-[#EAEAEA]"
-                    onClick={onBack}
-                />
-                <OnboardingButton
-                    label="Save Contact"
-                    className="lg:max-w-[271px]"
-                    onClick={handleSubmit}
-                />
-            </div>
-
-        </div>
+    updateProfile.mutate(
+      {
+        companyName,
+        registrationNumber: profile.registrationNumber,
+        bio: profile.bio,
+        website: profile.website,
+        publicEmail: profile.publicEmail,
+        headquarters: profile.headquarters,
+        contact: {
+          fullName: form.fullName.trim() || null,
+          emailAddress: form.emailAddress.trim() || null,
+          phoneNumber: form.phoneNumber.trim() || null,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success('Contact information updated');
+        },
+        onError: (saveError) => {
+          showApiErrorToast(saveError, 'Unable to update contact information.');
+        },
+      },
     );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Loading contact information...
+        </p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Unable to load contact information.
+        </p>
+      </div>
+    );
+  }
+
+  const supportChannels = [
+    {
+      id: 'whatsapp',
+      label: 'WhatsApp Support',
+      icon: MessageCircle,
+      isConnected: profile.contact.isWhatsAppConnected,
+    },
+    {
+      id: 'helpdesk',
+      label: 'Public Help Desk',
+      icon: Globe,
+      isConnected: profile.contact.hasPublicHelpDesk,
+    },
+  ] as const;
+
+  return (
+    <div className="w-full font-sans space-y-6">
+      <div>
+        <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
+          Contact Information
+        </h2>
+        <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
+          Manage how we and your investors can reach you.
+        </p>
+      </div>
+
+      <div className="grid lg:grid-cols-12 gap-6 items-start">
+        <div className="lg:col-span-7 bg-white border border-[#F4F5F7] rounded-xl p-6 space-y-4">
+          <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
+            Primary Contact
+          </h3>
+
+          <div className="space-y-1">
+            {CONTACT_FIELDS.map(({ key, label, type }) => (
+              <OnboardingInput
+                key={key}
+                label={label}
+                type={type}
+                value={form[key]}
+                onChange={(e) => handleInputChange(key, e.target.value)}
+                inputAreaStyle="text-[16px] text-[#505050] focus:ring-1"
+                labelStyle="text-[#505050]"
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="lg:col-span-5 bg-white border border-[#F4F5F7] rounded-xl p-6 space-y-4">
+          <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
+            Support Channels
+          </h3>
+
+          <div className="space-y-3">
+            {supportChannels.map(({ label, icon: Icon, isConnected }) => (
+              <div
+                key={label}
+                className="flex items-center justify-between p-3.5 bg-[#F4F5F7] rounded-lg border border-transparent"
+              >
+                <div className="flex items-center gap-3">
+                  <Icon className="w-4.5 h-4.5 text-[#858585]" />
+                  <span className="text-sm text-[#595959] font-medium">{label}</span>
+                </div>
+                <button
+                  type="button"
+                  className="text-[#B9C65B] text-[14px] font-medium cursor-pointer opacity-60"
+                  onClick={() =>
+                    toast.message('Coming soon', {
+                      description: `${label} integration is not available yet.`,
+                    })
+                  }
+                >
+                  {isConnected ? 'Manage' : 'Connect'}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="w-full flex flex-col lg:flex-row justify-end items-center gap-3 pt-4">
+        <OnboardingButton
+          label="Discard Changes"
+          variant="plain"
+          className="lg:max-w-[271px] border-[#EAEAEA]"
+          onClick={handleDiscard}
+          disabled={updateProfile.isPending}
+        />
+        <OnboardingButton
+          label="Save Contact"
+          className="lg:max-w-[271px]"
+          onClick={handleSubmit}
+          loading={updateProfile.isPending}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/components/settings/organisms/fundraiser/EmailAlert.tsx
+++ b/src/components/settings/organisms/fundraiser/EmailAlert.tsx
@@ -1,98 +1,133 @@
 'use client';
 
-import React, { useState } from 'react';
-import { Mail, } from 'lucide-react';
+import React, { useEffect } from 'react';
+import { Mail } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { Switch } from '@/components/ui/switch';
 import { GlobalSettingsCard } from '@/components/settings/molecules/GlobalSettingsCard';
+import {
+  useFundraiserNotificationPreferences,
+  useUpdateFundraiserNotificationPreferences,
+} from '@/hooks/use-fundraiser-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
+import type { FundraiserNotificationPreferences } from '@/types/settings';
 
-export interface AlertPreferenceItem {
-    id: string;
-    title: string;
-    description: string;
-}
-
-const ALERT_PREFERENCE: AlertPreferenceItem[] = [
-    {
-        id: 'campaignUpdates',
-        title: 'Campaign Updates',
-        description: 'Get notified when a campaign reaches a milestone.',
-    },
-    {
-        id: 'newInvestments',
-        title: 'New Investments',
-        description: 'Receive alerts when new investments are made in your campaigns.',
-    },
-    {
-        id: 'securityAlerts',
-        title: 'Security Alerts',
-        description: 'Get notified about login attempts and security-related activities.',
-    },
+const ALERT_PREFERENCE = [
+  {
+    id: 'campaignUpdates' as const,
+    title: 'Campaign Updates',
+    description: 'Get notified when a campaign reaches a milestone.',
+  },
+  {
+    id: 'newInvestments' as const,
+    title: 'New Investments',
+    description: 'Receive alerts when new investments are made in your campaigns.',
+  },
+  {
+    id: 'securityAlerts' as const,
+    title: 'Security Alerts',
+    description: 'Get notified about login attempts and security-related activities.',
+  },
 ];
 
 export function EmailAlerts() {
+  const { data: prefs, isLoading, isError, error } = useFundraiserNotificationPreferences();
+  const updatePrefs = useUpdateFundraiserNotificationPreferences();
 
-    const [preferences, setPreferences] = useState<Record<string, boolean>>({
-        campaignUpdates: true,
-        newInvestments: true,
-        securityAlerts: true,
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, 'Unable to load email alert preferences.');
+    }
+  }, [isError, error]);
+
+  const persist = (next: FundraiserNotificationPreferences) => {
+    updatePrefs.mutate(next, {
+      onError: (saveError) => {
+        showApiErrorToast(saveError, 'Unable to update email alert preferences.');
+      },
     });
+  };
 
-    const [isGlobalMuted, setIsGlobalMuted] = useState(false);
+  const handleToggle = (id: (typeof ALERT_PREFERENCE)[number]['id'], checked: boolean) => {
+    if (!prefs) return;
+    persist({
+      ...prefs,
+      email: { ...prefs.email, [id]: checked },
+    });
+  };
 
-    const handleToggle = (id: string, checked: boolean) => {
-        setPreferences(prev => ({ ...prev, [id]: checked }));
-    };
+  const handleGlobalMuteToggle = () => {
+    if (!prefs) return;
+    const muted = !prefs.email.muted;
+    persist({
+      ...prefs,
+      email: { ...prefs.email, muted },
+    });
+    toast.success(muted ? 'Email alerts muted' : 'Email alerts unmuted');
+  };
 
-    const handleGlobalMuteToggle = () => {
-        setIsGlobalMuted(prev => !prev);
-        console.log(`Global mute toggled state: ${!isGlobalMuted}`);
-    };
-
+  if (isLoading) {
     return (
-        <div className="w-full font-sans space-y-6">
-
-
-            <div>
-                <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
-                    Email Alerts
-                </h2>
-                <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
-                    Configure how you receive updates in your email
-                </p>
-            </div>
-
-            <div className="bg-white border border-[#F4F5F7] rounded-xl p-4 space-y-3">
-                {ALERT_PREFERENCE.map(({ id, title, description }) => (
-                    <div key={id} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
-                        <div className="flex items-center gap-4">
-                            <div className="p-3 bg-[#F9FAFB] rounded-lg text-[#F9FAFB] shrink-0 mt-0.5">
-                                <Mail className="w-5 h-5 text-[#1F1F1F]" />
-                            </div>
-                            <div>
-                                <h4 className="text-[16px] text-[#505050]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
-                                    {title}
-                                </h4>
-                                <p className="text-[14px] text-[#858585] mt-0.5">
-                                    {description}
-                                </p>
-                            </div>
-                        </div>
-                        <Switch
-                            checked={preferences[id]}
-                            onCheckedChange={(checked) => handleToggle(id, checked)}
-                            className="data-[state=checked]:bg-[#B9C65B]"
-                        />
-                    </div>
-                ))}
-            </div>
-
-            {/* Dark Bottom Row Component Block Card: Global Mute Panel Banner */}
-            <GlobalSettingsCard
-                buttonLabel={isGlobalMuted ? 'Muted' : 'Enable mute'}
-                onButtonClick={handleGlobalMuteToggle}
-            />
-
-        </div>
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Loading email alerts...
+        </p>
+      </div>
     );
+  }
+
+  if (!prefs) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Unable to load email alerts.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full font-sans space-y-6">
+      <div>
+        <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
+          Email Alerts
+        </h2>
+        <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
+          Configure how you receive updates in your email
+        </p>
+      </div>
+
+      <div className="bg-white border border-[#F4F5F7] rounded-xl p-4 space-y-3">
+        {ALERT_PREFERENCE.map(({ id, title, description }) => (
+          <div key={id} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
+            <div className="flex items-center gap-4">
+              <div className="p-3 bg-[#F9FAFB] rounded-lg text-[#F9FAFB] shrink-0 mt-0.5">
+                <Mail className="w-5 h-5 text-[#1F1F1F]" />
+              </div>
+              <div>
+                <h4 className="text-[16px] text-[#505050]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
+                  {title}
+                </h4>
+                <p className="text-[14px] text-[#858585] mt-0.5">
+                  {description}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.email[id]}
+              disabled={updatePrefs.isPending || prefs.email.muted}
+              onCheckedChange={(checked) => handleToggle(id, checked)}
+              className="data-[state=checked]:bg-[#B9C65B]"
+            />
+          </div>
+        ))}
+      </div>
+
+      <GlobalSettingsCard
+        buttonLabel={prefs.email.muted ? 'Muted' : 'Enable mute'}
+        onButtonClick={handleGlobalMuteToggle}
+      />
+    </div>
+  );
 }

--- a/src/components/settings/organisms/fundraiser/InAppNotification.tsx
+++ b/src/components/settings/organisms/fundraiser/InAppNotification.tsx
@@ -1,103 +1,136 @@
 'use client';
 
-import React, { useState } from 'react';
-import { Smartphone, } from 'lucide-react';
+import React, { useEffect } from 'react';
+import { Smartphone } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { Switch } from '@/components/ui/switch';
 import { GlobalSettingsCard } from '@/components/settings/molecules/GlobalSettingsCard';
+import {
+  useFundraiserNotificationPreferences,
+  useUpdateFundraiserNotificationPreferences,
+} from '@/hooks/use-fundraiser-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
+import type { FundraiserNotificationPreferences } from '@/types/settings';
 
-
-export interface NotificationPreferenceItem {
-    id: string;
-    title: string;
-    description: string;
-}
-
-const IN_APP_PREFERENCE_SCHEMA: NotificationPreferenceItem[] = [
-    {
-        id: 'realTimeActivity',
-        title: 'Real-time Activity',
-        description: 'Show popups for all platform activity.',
-    },
-    {
-        id: 'chatMessages',
-        title: 'Chat Messages',
-        description: 'Notify me when I receive a new message.',
-    },
-    {
-        id: 'systemStatus',
-        title: 'System Status',
-        description: 'Updates about platform maintenance and uptime.',
-    },
+const IN_APP_PREFERENCE_SCHEMA = [
+  {
+    id: 'realTimeActivity' as const,
+    title: 'Real-time Activity',
+    description: 'Show popups for all platform activity.',
+  },
+  {
+    id: 'chatMessages' as const,
+    title: 'Chat Messages',
+    description: 'Notify me when I receive a new message.',
+  },
+  {
+    id: 'systemStatus' as const,
+    title: 'System Status',
+    description: 'Updates about platform maintenance and uptime.',
+  },
 ];
 
 export function InAppNotifications() {
+  const { data: prefs, isLoading, isError, error } = useFundraiserNotificationPreferences();
+  const updatePrefs = useUpdateFundraiserNotificationPreferences();
 
-    const [preferences, setPreferences] = useState<Record<string, boolean>>({
-        realTimeActivity: true,
-        chatMessages: true,
-        systemStatus: true,
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, 'Unable to load in-app notification preferences.');
+    }
+  }, [isError, error]);
+
+  const persist = (next: FundraiserNotificationPreferences) => {
+    updatePrefs.mutate(next, {
+      onError: (saveError) => {
+        showApiErrorToast(saveError, 'Unable to update in-app notification preferences.');
+      },
     });
+  };
 
-    const [isGlobalMuted, setIsGlobalMuted] = useState(false);
+  const handleToggle = (
+    id: (typeof IN_APP_PREFERENCE_SCHEMA)[number]['id'],
+    checked: boolean,
+  ) => {
+    if (!prefs) return;
+    persist({
+      ...prefs,
+      inApp: { ...prefs.inApp, [id]: checked },
+    });
+  };
 
-    const handleToggle = (id: string, checked: boolean) => {
-        setPreferences(prev => ({ ...prev, [id]: checked }));
-    };
+  const handleGlobalMuteToggle = () => {
+    if (!prefs) return;
+    const muted = !prefs.inApp.muted;
+    persist({
+      ...prefs,
+      inApp: { ...prefs.inApp, muted },
+    });
+    toast.success(muted ? 'In-app notifications muted' : 'In-app notifications unmuted');
+  };
 
-    const handleGlobalMuteToggle = () => {
-        setIsGlobalMuted(prev => !prev);
-        console.log(`Global mute toggled state: ${!isGlobalMuted}`);
-    };
-
+  if (isLoading) {
     return (
-        <div className="w-full font-sans space-y-6">
-
-            {/* Header Text Section Frame */}
-            <div>
-                <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
-                    In-app Notifications
-                </h2>
-                <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
-                    Configure how you receive updates for this category.
-                </p>
-            </div>
-
-
-            <div className="bg-white border border-[#F4F5F7] rounded-xl p-4 space-y-3 ">
-                {IN_APP_PREFERENCE_SCHEMA.map(({ id, title, description }) => (
-                    <div key={id} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
-                        <div className="flex items-center gap-4">
-
-                            <div className="p-3 bg-[#F9FAFB] rounded-md shrink-0">
-                                <Smartphone className="w-6 h-6 text-[#858585]" />
-                            </div>
-
-                            <div>
-                                <h4 className="text-[16px] text-[#505050]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
-                                    {title}
-                                </h4>
-                                <p className="text-[14px] text-[#858585] mt-0.5">
-                                    {description}
-                                </p>
-                            </div>
-                        </div>
-                        <Switch
-                            checked={preferences[id]}
-                            onCheckedChange={(checked) => handleToggle(id, checked)}
-                            className="data-[state=checked]:bg-[#B9C65B]"
-                        />
-                    </div>
-                ))}
-            </div>
-
-            {/* Dark Bottom Row Component Block Card: Global Mute Banner */}
-            <GlobalSettingsCard
-                buttonLabel={isGlobalMuted ? 'Muted' : 'Enable mute'}
-                onButtonClick={handleGlobalMuteToggle}
-            />
-
-
-        </div>
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Loading in-app notifications...
+        </p>
+      </div>
     );
+  }
+
+  if (!prefs) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Unable to load in-app notifications.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full font-sans space-y-6">
+      <div>
+        <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
+          In-app Notifications
+        </h2>
+        <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
+          Configure how you receive updates for this category.
+        </p>
+      </div>
+
+      <div className="bg-white border border-[#F4F5F7] rounded-xl p-4 space-y-3 ">
+        {IN_APP_PREFERENCE_SCHEMA.map(({ id, title, description }) => (
+          <div key={id} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
+            <div className="flex items-center gap-4">
+              <div className="p-3 bg-[#F9FAFB] rounded-md shrink-0">
+                <Smartphone className="w-6 h-6 text-[#858585]" />
+              </div>
+              <div>
+                <h4 className="text-[16px] text-[#505050]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
+                  {title}
+                </h4>
+                <p className="text-[14px] text-[#858585] mt-0.5">
+                  {description}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.inApp[id]}
+              disabled={updatePrefs.isPending || prefs.inApp.muted}
+              onCheckedChange={(checked) => handleToggle(id, checked)}
+              className="data-[state=checked]:bg-[#B9C65B]"
+            />
+          </div>
+        ))}
+      </div>
+
+      <GlobalSettingsCard
+        buttonLabel={prefs.inApp.muted ? 'Muted' : 'Enable mute'}
+        onButtonClick={handleGlobalMuteToggle}
+      />
+    </div>
+  );
 }

--- a/src/components/settings/organisms/fundraiser/MarketingPreferences.tsx
+++ b/src/components/settings/organisms/fundraiser/MarketingPreferences.tsx
@@ -1,99 +1,136 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import { Megaphone } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { Switch } from '@/components/ui/switch';
 import { GlobalSettingsCard } from '@/components/settings/molecules/GlobalSettingsCard';
+import {
+  useFundraiserNotificationPreferences,
+  useUpdateFundraiserNotificationPreferences,
+} from '@/hooks/use-fundraiser-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
+import type { FundraiserNotificationPreferences } from '@/types/settings';
 
-export interface NotificationPreferenceItem {
-    id: string;
-    title: string;
-    description: string;
-}
-
-const MARKETING_PREFERENCE_SCHEMA: NotificationPreferenceItem[] = [
-    {
-        id: 'productNews',
-        title: 'Product News',
-        description: 'Stay updated with our latest features and improvements.',
-    },
-    {
-        id: 'investorTips',
-        title: 'Investor Tips',
-        description: 'Weekly insight on how to attract more investors.',
-    },
-    {
-        id: 'partner',
-        title: 'Partner',
-        description: 'Exclusive deals from our trusted partners.',
-    },
+const MARKETING_PREFERENCE_SCHEMA = [
+  {
+    id: 'productNews' as const,
+    title: 'Product News',
+    description: 'Stay updated with our latest features and improvements.',
+  },
+  {
+    id: 'investorTips' as const,
+    title: 'Investor Tips',
+    description: 'Weekly insight on how to attract more investors.',
+  },
+  {
+    id: 'partner' as const,
+    title: 'Partner',
+    description: 'Exclusive deals from our trusted partners.',
+  },
 ];
 
 export function MarketingPreferences() {
-    const [preferences, setPreferences] = useState<Record<string, boolean>>({
-        productNews: true,
-        investorTips: true,
-        partner: true,
+  const { data: prefs, isLoading, isError, error } = useFundraiserNotificationPreferences();
+  const updatePrefs = useUpdateFundraiserNotificationPreferences();
+
+  useEffect(() => {
+    if (isError) {
+      showApiErrorToast(error, 'Unable to load marketing preferences.');
+    }
+  }, [isError, error]);
+
+  const persist = (next: FundraiserNotificationPreferences) => {
+    updatePrefs.mutate(next, {
+      onError: (saveError) => {
+        showApiErrorToast(saveError, 'Unable to update marketing preferences.');
+      },
     });
+  };
 
-    const [isGlobalMuted, setIsGlobalMuted] = useState(false);
+  const handleToggle = (
+    id: (typeof MARKETING_PREFERENCE_SCHEMA)[number]['id'],
+    checked: boolean,
+  ) => {
+    if (!prefs) return;
+    persist({
+      ...prefs,
+      marketing: { ...prefs.marketing, [id]: checked },
+    });
+  };
 
-    const handleToggle = (id: string, checked: boolean) => {
-        setPreferences(prev => ({ ...prev, [id]: checked }));
-    };
+  const handleGlobalMuteToggle = () => {
+    if (!prefs) return;
+    const muted = !prefs.marketing.muted;
+    persist({
+      ...prefs,
+      marketing: { ...prefs.marketing, muted },
+    });
+    toast.success(muted ? 'Marketing emails muted' : 'Marketing emails unmuted');
+  };
 
-    const handleGlobalMuteToggle = () => {
-        setIsGlobalMuted(prev => !prev);
-        console.log(`Global mute toggled state: ${!isGlobalMuted}`);
-    };
-
+  if (isLoading) {
     return (
-        <div className="w-full font-sans space-y-6">
-
-            {/* Header Text Section Frame */}
-            <div>
-                <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
-                    Marketing Preferences
-                </h2>
-                <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
-                    Configure how you receive updates for this category.
-                </p>
-            </div>
-
-            <div className="bg-white border border-[#F4F5F7] rounded-xl p-4 space-y-3">
-                {MARKETING_PREFERENCE_SCHEMA.map(({ id, title, description }) => (
-                    <div key={id} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
-                        <div className="flex items-center gap-4">
-
-                            <div className="p-3 bg-[#F9FAFB] rounded-md shrink-0">
-                                <Megaphone className="w-6 h-6 text-[#858585]" />
-                            </div>
-
-                            <div>
-                                <h4 className="text-[16px] text-[#505050]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
-                                    {title}
-                                </h4>
-                                <p className="text-[14px] text-[#858585] mt-0.5">
-                                    {description}
-                                </p>
-                            </div>
-                        </div>
-                        <Switch
-                            checked={preferences[id]}
-                            onCheckedChange={(checked) => handleToggle(id, checked)}
-                            className="data-[state=checked]:bg-[#B9C65B]"
-                        />
-                    </div>
-                ))}
-            </div>
-
-            {/* Dark Bottom Row Component Block Card: Global Mute Banner */}
-            <GlobalSettingsCard
-                buttonLabel={isGlobalMuted ? 'Muted' : 'Enable mute'}
-                onButtonClick={handleGlobalMuteToggle}
-            />
-
-        </div>
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Loading marketing preferences...
+        </p>
+      </div>
     );
+  }
+
+  if (!prefs) {
+    return (
+      <div className="w-full font-sans">
+        <p className="text-[16px] text-[#858585]" style={TYPOGRAPHY.body}>
+          Unable to load marketing preferences.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full font-sans space-y-6">
+      <div>
+        <h2 className="text-[24px] lg:text-[28px] text-[#1B1B1B]" style={TYPOGRAPHY.heading}>
+          Marketing Preferences
+        </h2>
+        <p className="text-[14px] lg:text-[16px] text-[#505050] mt-0.5" style={TYPOGRAPHY.body}>
+          Configure how you receive updates for this category.
+        </p>
+      </div>
+
+      <div className="bg-white border border-[#F4F5F7] rounded-xl p-4 space-y-3">
+        {MARKETING_PREFERENCE_SCHEMA.map(({ id, title, description }) => (
+          <div key={id} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
+            <div className="flex items-center gap-4">
+              <div className="p-3 bg-[#F9FAFB] rounded-md shrink-0">
+                <Megaphone className="w-6 h-6 text-[#858585]" />
+              </div>
+              <div>
+                <h4 className="text-[16px] text-[#505050]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>
+                  {title}
+                </h4>
+                <p className="text-[14px] text-[#858585] mt-0.5">
+                  {description}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.marketing[id]}
+              disabled={updatePrefs.isPending || prefs.marketing.muted}
+              onCheckedChange={(checked) => handleToggle(id, checked)}
+              className="data-[state=checked]:bg-[#B9C65B]"
+            />
+          </div>
+        ))}
+      </div>
+
+      <GlobalSettingsCard
+        buttonLabel={prefs.marketing.muted ? 'Muted' : 'Enable mute'}
+        onButtonClick={handleGlobalMuteToggle}
+      />
+    </div>
+  );
 }

--- a/src/components/settings/organisms/fundraiser/SecurityAnd2fa.tsx
+++ b/src/components/settings/organisms/fundraiser/SecurityAnd2fa.tsx
@@ -1,106 +1,234 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Lock, Smartphone, Key, AlertTriangle, Shield } from 'lucide-react';
+import { toast } from 'sonner';
 import { TYPOGRAPHY } from '@/constants/styles';
 import { SecurityRowItem } from '@/components/settings/organisms/fundraiser/password2fa/SecurityRowItem';
 import { ActiveSessionsPanel } from '@/components/settings/organisms/fundraiser/password2fa/ActiveSessionsPanel';
 import { LoginHistoryPanel } from '@/components/settings/organisms/fundraiser/password2fa/LoginHistoryPanel';
-
+import { OnboardingInput } from '@/components/onboarding/molecules/OnboardingInput';
+import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useChangePassword } from '@/hooks/use-settings';
+import { showApiErrorToast } from '@/lib/error-feedback';
 
 interface SecurityAnd2faProps {
-    targetSection?: 'password-2fa' | 'authorized-devices' | 'login-history' | string;
+  targetSection?: 'password-2fa' | 'authorized-devices' | 'login-history' | string;
 }
 
 export function SecurityAnd2fa({ targetSection }: SecurityAnd2faProps) {
+  const changePassword = useChangePassword();
+  const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
+  const [passwords, setPasswords] = useState({
+    current: '',
+    new: '',
+    confirm: '',
+  });
 
-    useEffect(() => {
+  useEffect(() => {
+    if (!targetSection || targetSection === 'password-2fa') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
 
-        if (!targetSection || targetSection === 'password-2fa') {
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-            return;
-        }
+    const element = document.getElementById(targetSection);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [targetSection]);
 
-        const element = document.getElementById(targetSection);
-        if (element) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-    }, [targetSection]);
+  const handlePasswordFieldChange = (field: keyof typeof passwords, value: string) => {
+    setPasswords((prev) => ({ ...prev, [field]: value }));
+  };
 
-    return (
-        <div className="w-full font-sans space-y-6">
+  const resetPasswordForm = () => {
+    setPasswords({ current: '', new: '', confirm: '' });
+  };
 
-            {/* Security Center Header Banner */}
-            <div className="relative overflow-hidden bg-[#021310] text-white rounded-md p-6 md:p-8.5 flex flex-col md:flex-row items-center justify-between gap-6">
-                <div className="max-w-2xl z-10">
-                    <h2 className="text-[24px] md:text-[28px] text-[#F4F5F7]" style={TYPOGRAPHY.heading}>
-                        Security Center
-                    </h2>
-                    <p className="text-[14px] text-[#858585] mt-2 leading-relaxed" style={TYPOGRAPHY.body}>
-                        Keep your account secure by enabling two-factor authentication and monitoring your login activity. We recommend using a hardware key for maximum security.
-                    </p>
-                </div>
+  const handleUpdatePassword = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (passwords.new !== passwords.confirm) {
+      toast.error('New password and confirmation do not match.');
+      return;
+    }
 
-                {/* Score Widget */}
-                <div className="relative z-10 bg-white/8 border border-white/10 rounded-xl p-4 min-w-[160px] text-center shrink-0">
-                    <span className="block text-[14px] text-[#B9C65B] font-medium">Security Score</span>
-                    <div className="text-[24px] text-[#F4F5F7] my-0.5" style={TYPOGRAPHY.heading}>
-                        82<span className="text-[19px] text-[#A8A8A8]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>/100</span>
-                    </div>
-                    <div className="flex items-center justify-center gap-1 text-[12px] text-[#DCA73B]">
-                        <AlertTriangle className="w-4 h-4" />
-                        <span>Action required</span>
-                    </div>
-                </div>
-
-                {/* Background Emblem Graphic */}
-                <div className="hidden absolute -right-18.5 -top-18 bottom-0 opacity-10 pointer-events-none lg:flex items-center pr-10">
-
-                    <Shield className="w-64 h-64 text-white" strokeWidth={1.3} />
-                </div>
-            </div>
-
-            {/* Main Security Actions Panel */}
-            <div className="bg-white border border-[#F4F5F7] rounded-md p-6">
-                <SecurityRowItem
-                    icon={Lock}
-                    title="Account Password"
-                    description="Last change 3 months ago. We recommend changing it every 6 months."
-                    buttonLabel="Change Password"
-                    onActionClick={() => console.log('Change Password Triggered')}
-                />
-
-                <SecurityRowItem
-                    icon={Smartphone}
-                    title="Two-Factor Authentication"
-                    badge={{ label: 'DISABLED', variant: 'disabled' }}
-                    description="Add an extra layer of security to your account using an authenticator app."
-                    buttonLabel="Setup 2FA"
-                    onActionClick={() => console.log('Setup 2FA Triggered')}
-                />
-
-                <SecurityRowItem
-                    icon={Key}
-                    title="Hardware Security Keys"
-                    badge={{ label: 'ENABLE', variant: 'enable' }}
-                    description="Use Physical Keys like Yubikey for the highest level of account protection."
-                    buttonLabel="Manage Keys"
-                    onActionClick={() => console.log('Manage Keys Triggered')}
-                />
-            </div>
-
-            {/* Bottom Row Grid: Active Sessions & Login History */}
-            <div className="grid md:grid-cols-2 gap-6">
-                <div id="authorized-devices" className="scroll-mt-6">
-                    <ActiveSessionsPanel />
-                </div>
-
-
-                <div id="login-history" className="scroll-mt-6">
-                    <LoginHistoryPanel />
-                </div>
-            </div>
-
-        </div>
+    changePassword.mutate(
+      {
+        currentPassword: passwords.current,
+        newPassword: passwords.new,
+        confirmPassword: passwords.confirm,
+      },
+      {
+        onSuccess: () => {
+          toast.success('Password updated');
+          resetPasswordForm();
+          setIsPasswordDialogOpen(false);
+        },
+        onError: (error) => {
+          showApiErrorToast(error, 'Unable to update password.');
+        },
+      },
     );
+  };
+
+  const isPasswordMismatch = passwords.confirm.length > 0 && passwords.new !== passwords.confirm;
+  const isSubmitDisabled =
+    changePassword.isPending
+    || isPasswordMismatch
+    || !passwords.current
+    || !passwords.new
+    || !passwords.confirm;
+
+  return (
+    <div className="w-full font-sans space-y-6">
+      <div className="relative overflow-hidden bg-[#021310] text-white rounded-md p-6 md:p-8.5 flex flex-col md:flex-row items-center justify-between gap-6">
+        <div className="max-w-2xl z-10">
+          <h2 className="text-[24px] md:text-[28px] text-[#F4F5F7]" style={TYPOGRAPHY.heading}>
+            Security Center
+          </h2>
+          <p className="text-[14px] text-[#858585] mt-2 leading-relaxed" style={TYPOGRAPHY.body}>
+            Keep your account secure by enabling two-factor authentication and monitoring your login activity. We recommend using a hardware key for maximum security.
+          </p>
+        </div>
+
+        <div className="relative z-10 bg-white/8 border border-white/10 rounded-xl p-4 min-w-[160px] text-center shrink-0">
+          <span className="block text-[14px] text-[#B9C65B] font-medium">Security Score</span>
+          <div className="text-[24px] text-[#F4F5F7] my-0.5" style={TYPOGRAPHY.heading}>
+            82<span className="text-[19px] text-[#A8A8A8]" style={{ ...TYPOGRAPHY.body, fontWeight: 500 }}>/100</span>
+          </div>
+          <div className="flex items-center justify-center gap-1 text-[12px] text-[#DCA73B]">
+            <AlertTriangle className="w-4 h-4" />
+            <span>Action required</span>
+          </div>
+        </div>
+
+        <div className="hidden absolute -right-18.5 -top-18 bottom-0 opacity-10 pointer-events-none lg:flex items-center pr-10">
+          <Shield className="w-64 h-64 text-white" strokeWidth={1.3} />
+        </div>
+      </div>
+
+      <div className="bg-white border border-[#F4F5F7] rounded-md p-6">
+        <SecurityRowItem
+          icon={Lock}
+          title="Account Password"
+          description="Last change 3 months ago. We recommend changing it every 6 months."
+          buttonLabel="Change Password"
+          onActionClick={() => setIsPasswordDialogOpen(true)}
+        />
+
+        <SecurityRowItem
+          icon={Smartphone}
+          title="Two-Factor Authentication"
+          badge={{ label: 'DISABLED', variant: 'disabled' }}
+          description="Add an extra layer of security to your account using an authenticator app."
+          buttonLabel="Setup 2FA"
+          onActionClick={() =>
+            toast.message('Coming soon', {
+              description: 'Two-factor authentication setup is not available yet.',
+            })
+          }
+        />
+
+        <SecurityRowItem
+          icon={Key}
+          title="Hardware Security Keys"
+          badge={{ label: 'ENABLE', variant: 'enable' }}
+          description="Use Physical Keys like Yubikey for the highest level of account protection."
+          buttonLabel="Manage Keys"
+          onActionClick={() =>
+            toast.message('Coming soon', {
+              description: 'Hardware security key management is not available yet.',
+            })
+          }
+        />
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div id="authorized-devices" className="scroll-mt-6">
+          <ActiveSessionsPanel />
+        </div>
+
+        <div id="login-history" className="scroll-mt-6">
+          <LoginHistoryPanel />
+        </div>
+      </div>
+
+      <Dialog
+        open={isPasswordDialogOpen}
+        onOpenChange={(open) => {
+          setIsPasswordDialogOpen(open);
+          if (!open) {
+            resetPasswordForm();
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Change Password</DialogTitle>
+            <DialogDescription>
+              Enter your current password and choose a new one.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleUpdatePassword} className="space-y-4">
+            <OnboardingInput
+              label="Current Password"
+              placeholder="Enter current password"
+              type="password"
+              value={passwords.current}
+              onChange={(e) => handlePasswordFieldChange('current', e.target.value)}
+              inputAreaStyle="bg-[#FFFFFF] text-[16px] text-[#858585] pr-10"
+            />
+            <OnboardingInput
+              label="New Password"
+              placeholder="Enter new password"
+              type="password"
+              value={passwords.new}
+              onChange={(e) => handlePasswordFieldChange('new', e.target.value)}
+              inputAreaStyle="bg-[#FFFFFF] text-[16px] text-[#858585] pr-10"
+            />
+            <div>
+              <OnboardingInput
+                label="Confirm new password"
+                placeholder="Confirm new password"
+                type="password"
+                value={passwords.confirm}
+                onChange={(e) => handlePasswordFieldChange('confirm', e.target.value)}
+                inputAreaStyle="bg-[#FFFFFF] text-[16px] text-[#858585] pr-10"
+              />
+              {isPasswordMismatch && (
+                <p className="text-[12px] text-[#D4001A] mt-1">Passwords do not match.</p>
+              )}
+            </div>
+
+            <DialogFooter className="gap-2 sm:gap-2">
+              <OnboardingButton
+                type="button"
+                label="Cancel"
+                variant="plain"
+                className="my-0 max-w-none"
+                onClick={() => setIsPasswordDialogOpen(false)}
+                disabled={changePassword.isPending}
+              />
+              <OnboardingButton
+                type="submit"
+                label="Update Password"
+                className="my-0 max-w-none"
+                loading={changePassword.isPending}
+                disabled={isSubmitDisabled}
+              />
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,8 @@ export const CACHE_KEY_PAYMENT_METHODS = ["payment-methods"] as const;
 export const CACHE_KEY_WATCHLIST = ["watchlist"] as const;
 export const CACHE_KEY_INVESTOR_PROFILE = ["investor-profile"] as const;
 export const CACHE_KEY_INVESTOR_ACCOUNT = ["investor-account"] as const;
+export const CACHE_KEY_FUNDRAISER_SETTINGS_PROFILE = ["fundraiser-settings-profile"] as const;
+export const CACHE_KEY_FUNDRAISER_SETTINGS_NOTIFICATIONS = ["fundraiser-settings-notifications"] as const;
 
 export const ACCESS_TOKEN_KEY = "access_token";
 export const REFRESH_TOKEN_KEY = "refresh_token";

--- a/src/hooks/use-fundraiser-settings.ts
+++ b/src/hooks/use-fundraiser-settings.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CACHE_KEY_FUNDRAISER_SETTINGS_NOTIFICATIONS,
+  CACHE_KEY_FUNDRAISER_SETTINGS_PROFILE,
+} from "@/constants";
+import fundraiserSettingsService from "@/services/fundraiserSettingsService";
+import type {
+  UpdateFundraiserNotificationPreferencesRequest,
+  UpdateFundraiserSettingsProfileRequest,
+} from "@/types/settings";
+
+export function useFundraiserSettingsProfile() {
+  return useQuery({
+    queryKey: CACHE_KEY_FUNDRAISER_SETTINGS_PROFILE,
+    queryFn: () => fundraiserSettingsService.getProfile(),
+  });
+}
+
+export function useUpdateFundraiserSettingsProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: UpdateFundraiserSettingsProfileRequest) =>
+      fundraiserSettingsService.updateProfile(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(CACHE_KEY_FUNDRAISER_SETTINGS_PROFILE, data);
+    },
+  });
+}
+
+export function useFundraiserNotificationPreferences() {
+  return useQuery({
+    queryKey: CACHE_KEY_FUNDRAISER_SETTINGS_NOTIFICATIONS,
+    queryFn: () => fundraiserSettingsService.getNotifications(),
+  });
+}
+
+export function useUpdateFundraiserNotificationPreferences() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: UpdateFundraiserNotificationPreferencesRequest) =>
+      fundraiserSettingsService.updateNotifications(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(CACHE_KEY_FUNDRAISER_SETTINGS_NOTIFICATIONS, data);
+    },
+  });
+}

--- a/src/services/fundraiserSettingsService.ts
+++ b/src/services/fundraiserSettingsService.ts
@@ -1,0 +1,64 @@
+import { request, unwrap } from "@/services/api-client";
+import type { ApiResponse } from "@/types/api";
+import type {
+  FundraiserNotificationPreferences,
+  FundraiserSettingsProfile,
+  UpdateFundraiserNotificationPreferencesRequest,
+  UpdateFundraiserSettingsProfileRequest,
+} from "@/types/settings";
+import { toApiError } from "@/lib/api-error";
+
+const PROFILE_BASE = "/api/fundraisers/me/settings/profile";
+const NOTIFICATIONS_BASE = "/api/fundraisers/me/settings/notifications";
+
+async function getProfile(): Promise<FundraiserSettingsProfile> {
+  try {
+    const res = await request.get<ApiResponse<FundraiserSettingsProfile>>(PROFILE_BASE);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function updateProfile(
+  payload: UpdateFundraiserSettingsProfileRequest,
+): Promise<FundraiserSettingsProfile> {
+  try {
+    const res = await request.put<ApiResponse<FundraiserSettingsProfile>>(PROFILE_BASE, payload);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function getNotifications(): Promise<FundraiserNotificationPreferences> {
+  try {
+    const res = await request.get<ApiResponse<FundraiserNotificationPreferences>>(NOTIFICATIONS_BASE);
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+async function updateNotifications(
+  payload: UpdateFundraiserNotificationPreferencesRequest,
+): Promise<FundraiserNotificationPreferences> {
+  try {
+    const res = await request.put<ApiResponse<FundraiserNotificationPreferences>>(
+      NOTIFICATIONS_BASE,
+      payload,
+    );
+    return unwrap(res.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const fundraiserSettingsService = {
+  getProfile,
+  updateProfile,
+  getNotifications,
+  updateNotifications,
+};
+
+export default fundraiserSettingsService;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -49,3 +49,70 @@ export interface InvestorAccount {
   investmentLimits: InvestorInvestmentLimits | null;
   complianceChecks: InvestorComplianceCheck[];
 }
+
+export interface FundraiserSettingsContact {
+  fullName: string | null;
+  emailAddress: string | null;
+  phoneNumber: string | null;
+  isWhatsAppConnected: boolean;
+  hasPublicHelpDesk: boolean;
+}
+
+export interface FundraiserSettingsProfile {
+  companyName: string | null;
+  registrationNumber: string | null;
+  bio: string | null;
+  website: string | null;
+  publicEmail: string | null;
+  headquarters: string | null;
+  locationLabel: string | null;
+  companyAvatarUrl: string | null;
+  companyAvatarFallback: string | null;
+  completionPercentage: number;
+  contact: FundraiserSettingsContact;
+}
+
+export interface UpdateFundraiserSettingsContactRequest {
+  fullName?: string | null;
+  emailAddress?: string | null;
+  phoneNumber?: string | null;
+}
+
+export interface UpdateFundraiserSettingsProfileRequest {
+  companyName: string;
+  registrationNumber?: string | null;
+  bio?: string | null;
+  website?: string | null;
+  publicEmail?: string | null;
+  headquarters?: string | null;
+  contact?: UpdateFundraiserSettingsContactRequest | null;
+}
+
+export interface FundraiserEmailNotificationPrefs {
+  campaignUpdates: boolean;
+  newInvestments: boolean;
+  securityAlerts: boolean;
+  muted: boolean;
+}
+
+export interface FundraiserInAppNotificationPrefs {
+  realTimeActivity: boolean;
+  chatMessages: boolean;
+  systemStatus: boolean;
+  muted: boolean;
+}
+
+export interface FundraiserMarketingNotificationPrefs {
+  productNews: boolean;
+  investorTips: boolean;
+  partner: boolean;
+  muted: boolean;
+}
+
+export interface FundraiserNotificationPreferences {
+  email: FundraiserEmailNotificationPrefs;
+  inApp: FundraiserInAppNotificationPrefs;
+  marketing: FundraiserMarketingNotificationPrefs;
+}
+
+export type UpdateFundraiserNotificationPreferencesRequest = FundraiserNotificationPreferences;


### PR DESCRIPTION
## Summary
- Wire company profile, contact information, and root brand card to `GET/PUT /api/fundraisers/me/settings/profile`.
- Persist email / in-app / marketing notification toggles via settings notifications API.
- Connect Change Password dialog to existing `POST /api/auth/change-password` (2FA/devices/history remain mock).

Depends on the paired API PR on `feature/fundraiser-settings-api`.
Closes #226 (UI half; with API PR).

## Test plan
- [x] Login as fundraiser and open `/settings` — brand card shows real company name/location
- [x] Edit and save Company Profile; refresh confirms persistence
- [x] Edit and save Contact Information
- [x] Toggle Email / In-app / Marketing prefs and mute; refresh confirms persistence
- [x] Change Password dialog succeeds with correct current password and errors on wrong password
- [x] Team / bank / tax / 2FA flows remain mock or “coming soon”


Made with [Cursor](https://cursor.com)