### PR TITLE
Normalize date-only handling

### DIFF
--- a/src/app/(dashboard)/campaigns/components/Campaigns.tsx
+++ b/src/app/(dashboard)/campaigns/components/Campaigns.tsx
@@ -12,6 +12,7 @@ import {
     useFundraiserCampaign,
     useFundraiserCampaignUpdates,
 } from '@/hooks/use-fundraiser-campaign'
+import { parseDateValue } from '@/lib/date'
 import { showApiErrorToast } from '@/lib/error-feedback'
 import { CampaignPageSkeleton } from '@/components/skeletons/campaign-skeletons'
 
@@ -26,8 +27,8 @@ function buildAbsoluteShareUrl(publicPath: string | null | undefined, slug: stri
 
 function formatUpdateDate(value: string | null) {
     if (!value) return 'Draft'
-    const date = new Date(value)
-    if (Number.isNaN(date.getTime())) return 'Draft'
+    const date = parseDateValue(value)
+    if (!date) return 'Draft'
     return date.toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',

--- a/src/app/(dashboard)/dashboard/components/data-table.tsx
+++ b/src/app/(dashboard)/dashboard/components/data-table.tsx
@@ -18,6 +18,7 @@ import { usePathname, useRouter } from "next/navigation"
 import allInvestmentsRaw from "@/data/dashboardInvestmentData.json"
 import { InvestmentData, RISK_COLORS } from "@/types/dashboard"
 import { buildCheckoutPath } from "@/lib/investment-checkout"
+import { parseDateValue } from "@/lib/date"
 import type { DashboardHolding } from "@/types/dashboard-api"
 
 interface DataTableProps {
@@ -28,8 +29,8 @@ interface DataTableProps {
 }
 
 const formatDashboardDate = (value: string) => {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
+  const date = parseDateValue(value)
+  if (!date) {
     return value
   }
 

--- a/src/app/(dashboard)/documents/components/Documents.tsx
+++ b/src/app/(dashboard)/documents/components/Documents.tsx
@@ -9,6 +9,7 @@ import {
   useFundraiserDocuments,
   useUploadFundraiserDocument,
 } from "@/hooks/use-fundraiser-documents"
+import { parseDateValue } from "@/lib/date"
 import { showApiErrorToast } from "@/lib/error-feedback"
 import type { DocumentItem } from "@/components/documents/molecules/DocumentTable"
 import type { FundraiserDocumentStatus } from "@/types/fundraiser-documents-api"
@@ -20,9 +21,9 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function formatDate(value: string): string {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return "—"
+function formatDate(value: string | number): string {
+  const date = parseDateValue(value)
+  if (!date) return "—"
   return date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
@@ -71,11 +72,11 @@ export default function Documents() {
   const latestUpdatedLabel = useMemo(() => {
     if (!data?.items?.length) return null
     const latest = data.items.reduce((max, item) => {
-      const ts = new Date(item.lastUpdatedAt).getTime()
+      const ts = parseDateValue(item.lastUpdatedAt)?.getTime() ?? Number.NaN
       return Number.isNaN(ts) ? max : Math.max(max, ts)
     }, 0)
     if (!latest) return null
-    return formatDate(new Date(latest).toISOString())
+    return formatDate(latest)
   }, [data?.items])
 
   const handleDownload = (doc: DocumentItem) => {

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { StatCards } from "./components/stat-cards"
 import { DataTable } from "./components/data-table"
+import { todayDateInputValue } from "@/lib/date"
 
 import initialUsersData from "./data.json"
 
@@ -49,8 +50,8 @@ export default function UsersPage() {
       plan: userData.plan,
       billing: userData.billing,
       status: userData.status,
-      joinedDate: new Date().toISOString().split('T')[0],
-      lastLogin: new Date().toISOString().split('T')[0],
+      joinedDate: todayDateInputValue(),
+      lastLogin: todayDateInputValue(),
     }
     setUsers(prev => [newUser, ...prev])
   }

--- a/src/components/investment/organisms/updates-section.tsx
+++ b/src/components/investment/organisms/updates-section.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { UpdateItem } from '@/components/investment/molecules/update-item'
+import { parseDateValue } from '@/lib/date'
 import type { OfferingUpdate } from '@/types/investment'
 
 interface UpdatesSectionProps {
@@ -7,7 +8,10 @@ interface UpdatesSectionProps {
 }
 
 function formatUpdateDate(isoDate: string): string {
-  const date = new Date(isoDate)
+  const date = parseDateValue(isoDate)
+  if (!date) {
+    return isoDate
+  }
   const now = new Date()
   const isToday =
     date.getFullYear() === now.getFullYear() &&

--- a/src/components/investors/molecules/InboxFeed.tsx
+++ b/src/components/investors/molecules/InboxFeed.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import Image from 'next/image'
 import { MessageSquare, CornerUpLeft, EyeOff, Eye } from 'lucide-react'
 import { OnboardingButton } from '@/components/onboarding/molecules/OnboardingButton'
+import { parseDateValue } from '@/lib/date'
 import type { FundraiserInvestorMessage } from '@/types/fundraiser-investors-api'
 import { InboxFeedSkeleton } from '@/components/skeletons/table-skeletons'
 
@@ -21,8 +22,8 @@ interface InboxFeedProps {
 }
 
 function formatTimeAgo(value: string) {
-    const date = new Date(value)
-    if (Number.isNaN(date.getTime())) return ''
+    const date = parseDateValue(value)
+    if (!date) return ''
     const diffMs = Date.now() - date.getTime()
     const minutes = Math.max(1, Math.round(diffMs / 60_000))
     if (minutes < 60) return `${minutes}m ago`

--- a/src/components/investors/molecules/QIIParticipation.tsx
+++ b/src/components/investors/molecules/QIIParticipation.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React from 'react'
+import { parseDateValue } from '@/lib/date'
 import type { FundraiserQiiParticipationItem } from '@/types/fundraiser-investors-api'
 import { RecordTableRowSkeleton } from '@/components/skeletons/table-skeletons'
 
@@ -15,8 +16,8 @@ function formatCommitment(amount: number, currency: string) {
 }
 
 function formatDate(value: string) {
-    const date = new Date(value)
-    if (Number.isNaN(date.getTime())) return '—'
+    const date = parseDateValue(value)
+    if (!date) return '—'
     return date.toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',

--- a/src/components/onboarding/molecules/OnboardingInput.tsx
+++ b/src/components/onboarding/molecules/OnboardingInput.tsx
@@ -5,6 +5,7 @@ import { Eye, EyeOff, LucideIcon } from "lucide-react"
 import DatePicker from "react-datepicker"
 import "react-datepicker/dist/react-datepicker.css"
 import { TYPOGRAPHY } from "@/constants/styles"
+import { formatDateInputValue, parseDateValue } from "@/lib/date"
 import { cn } from "@/lib/utils"
 
 interface CustomChangeEvent {
@@ -40,15 +41,7 @@ type OnboardingRef = HTMLInputElement | HTMLTextAreaElement
 
 const getDateObject = (val: unknown): Date | null => {
     if (!val) return null;
-    if (val instanceof Date) return val;
-
-    // If it's a string or number, try to parse it
-    if (typeof val === 'string' || typeof val === 'number') {
-        const parsed = new Date(val);
-        return isNaN(parsed.getTime()) ? null : parsed;
-    }
-
-    return null;
+    return parseDateValue(val as string | number | Date | null | undefined);
 };
 
 export const OnboardingInput = React.forwardRef<OnboardingRef, InputProps>(
@@ -87,7 +80,7 @@ export const OnboardingInput = React.forwardRef<OnboardingRef, InputProps>(
                         <DatePicker
                             selected={getDateObject(value)}
                             onChange={(date: Date | null) => {
-                                const stringValue = date ? date.toISOString().split('T')[0] : "";
+                                const stringValue = date ? formatDateInputValue(date) : "";
                                 onChange?.({ target: { name: props.name, value: stringValue } });
                             }}
                             onBlur={onBlur}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,38 @@
+export function parseDateValue(value: string | number | Date | null | undefined): Date | null {
+  if (value == null || value === "") return null
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+
+  if (typeof value === "number") {
+    const parsed = new Date(value)
+    return Number.isNaN(parsed.getTime()) ? null : parsed
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const isoDateMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (isoDateMatch) {
+    const [, year, month, day] = isoDateMatch
+    return new Date(Number(year), Number(month) - 1, Number(day))
+  }
+
+  const dmyMatch = trimmed.match(/^(\d{2})\/(\d{2})\/(\d{4})$/)
+  if (dmyMatch) {
+    const [, day, month, year] = dmyMatch
+    return new Date(Number(year), Number(month) - 1, Number(day))
+  }
+
+  const parsed = new Date(trimmed)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export function formatDateInputValue(value: Date): string {
+  const year = value.getFullYear()
+  const month = String(value.getMonth() + 1).padStart(2, "0")
+  const day = String(value.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+export function todayDateInputValue(): string {
+  return formatDateInputValue(new Date())
+}

--- a/src/lib/settings-mappers.ts
+++ b/src/lib/settings-mappers.ts
@@ -4,6 +4,7 @@ import type {
   ComplianceCheckItem,
   InvestmentLimitsMetrics,
 } from "@/components/settings/organisms/investors/Account";
+import { parseDateValue } from "@/lib/date";
 
 export interface ProfileFormData {
   firstName: string;
@@ -47,8 +48,8 @@ export function mapFormDataToUpdateRequest(
 }
 
 function formatAccountDate(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
+  const date = parseDateValue(value);
+  if (!date) {
     return value;
   }
 


### PR DESCRIPTION
## Summary
- fix onboarding date picker serialization to avoid timezone-driven day shifts
- add a shared date utility for date-only parsing and formatting
- update key dashboard and settings display paths to use the shared parser

## Validation
- npm run type-check
- eslint --fix --max-warnings=0 (via commit hook)