### PR TITLE
Update onboarding CAC UI flows

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -10,6 +10,9 @@ import { InfoBanner } from "@/components/dashboard/organisms/InfoBanner";
 import { useRouter } from "next/navigation";
 import { SyncUserProfile } from "@/components/auth/sync-user-profile";
 import { useUserStore } from "@/store/userStore";
+import { useQuery } from "@tanstack/react-query";
+import onboardingService from "@/services/onboardingService";
+import { mapOnboardingStepToUiStep } from "@/lib/onboarding-hydration";
 
 export default function DashboardLayout({
   children,
@@ -20,9 +23,7 @@ export default function DashboardLayout({
 
   const [isMobile, setIsMobile] = useState(false);
   const [hasHydrated, setHasHydrated] = useState(false);
-
-  // Read the real-time KYC validation status from your store
-  const isKycCompleted = useUserStore((state) => state.isKycCompleted);
+  const userType = useUserStore((state) => state.userType);
 
   // Monitor store hydration to avoid server-client state mismatch
   useEffect(() => {
@@ -35,6 +36,42 @@ export default function DashboardLayout({
   }, []);
 
   const router = useRouter();
+  const onboardingQuery = useQuery({
+    queryKey: ["dashboard-onboarding-banner"],
+    queryFn: () => onboardingService.getOnboarding(),
+    enabled: hasHydrated,
+  });
+
+  const onboarding = onboardingQuery.data;
+  const onboardingStatus = onboarding?.status ? String(onboarding.status) : null;
+  const isPendingReview = onboardingStatus === "Submitted" || onboardingStatus === "UnderReview";
+  const isActivated = onboardingStatus === "Activated";
+  const isActionRequired =
+    !isActivated &&
+    !isPendingReview &&
+    onboarding != null &&
+    String(onboarding.currentStep) !== "Submitted" &&
+    String(onboarding.currentStep) !== "4";
+  const shouldShowKycBanner = hasHydrated && (isPendingReview || isActionRequired);
+
+  const handleBannerAction = () => {
+    if (isPendingReview) {
+      router.push("/documents");
+      return;
+    }
+
+    if (!onboarding) {
+      router.push("/settings");
+      return;
+    }
+
+    const investorUserType =
+      userType === "corporate" || userType === "fundraiser"
+        ? userType
+        : "individual";
+    const step = mapOnboardingStepToUiStep(onboarding.currentStep, investorUserType);
+    router.push(`/onboarding/${investorUserType}/${step}`);
+  };
 
   return (
     <>
@@ -58,11 +95,12 @@ export default function DashboardLayout({
       <SidebarInset className="bg-[#F8F8F8F8]">
         <DashboardHeader />
 
-        {hasHydrated && !isKycCompleted && (
+        {shouldShowKycBanner && (
           <div className='pt-8 px-4 lg:px-8'>
             <InfoBanner
               type='kyc'
-              onActionClick={() => router.push("/settings")}
+              state={isPendingReview ? "pending" : "action-required"}
+              onActionClick={handleBannerAction}
             />
           </div>
         )}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -56,6 +56,11 @@ export default function DashboardLayout({
 
   const handleBannerAction = () => {
     if (isPendingReview) {
+      if (userType === "individual" || userType === "corporate") {
+        router.push("/settings?tab=account");
+        return;
+      }
+
       router.push("/documents");
       return;
     }

--- a/src/components/dashboard/organisms/InfoBanner.tsx
+++ b/src/components/dashboard/organisms/InfoBanner.tsx
@@ -5,17 +5,31 @@ import { AlertTriangle } from 'lucide-react';
 import { TYPOGRAPHY } from '@/constants/styles';
 
 export type BannerType = 'kyc' | 'email-verification' | 'two-factor' | 'bank-account';
+export type BannerState = 'action-required' | 'pending';
 
 interface InfoBannerProps {
     type: BannerType;
+    state?: BannerState;
     onActionClick?: () => void;
 }
 
-export function InfoBanner({ type, onActionClick }: InfoBannerProps) {
+export function InfoBanner({ type, state = 'action-required', onActionClick }: InfoBannerProps) {
 
     const getBannerConfig = () => {
         switch (type) {
             case 'kyc':
+                if (state === 'pending') {
+                    return {
+                        title: 'KYC Under Review',
+                        description: 'Your verification has been submitted and is currently under review.',
+                        buttonText: 'View Application',
+                        bgClass: 'bg-[#E8F1FD] border-[#7CA6E8]',
+                        titleColor: 'text-[#1A1A1A]',
+                        descColor: 'text-[#555555]',
+                        btnClass: 'bg-[#3B73B5] hover:bg-[#315f95] text-white',
+                        icon: <AlertTriangle className="w-5 h-5 text-[#3B73B5]" />
+                    };
+                }
                 return {
                     title: 'Complete KYC',
                     description: 'Update your personal details and profile to unlock all features',

--- a/src/components/onboarding/molecules/ReviewCard.tsx
+++ b/src/components/onboarding/molecules/ReviewCard.tsx
@@ -24,10 +24,13 @@ export function ReviewCard({ title, items, isStatusType, onEditClick }: ReviewCa
         const val = item.value;
         const label = item.label?.toLowerCase();
         const isCorporate = investorUserType === "corporate";
+        const isFileValue =
+            typeof File !== "undefined" &&
+            val instanceof File;
 
         if (val === null || val === undefined) return "Not set";
 
-        if (val instanceof File || val === "File Uploaded") {
+        if (isFileValue || val === "File Uploaded") {
             if (isCorporate) {
                 return label?.includes("selfie") ? "Verified" : "Uploaded";
             }

--- a/src/components/onboarding/organisms/StepRenderer.tsx
+++ b/src/components/onboarding/organisms/StepRenderer.tsx
@@ -81,7 +81,7 @@ export default function StepRenderer({ step, investorUserTypeFromUrl }: StepRend
             return <IdentityVerification onBack={navigateToBack} onNext={navigateToNext} />;
 
         case "application-fee":
-            return <PaymentApplicationFee />
+            return <PaymentApplicationFee onBack={navigateToBack} />
 
         case "review":
             return <Review onBack={navigateToBack} onNext={navigateToNext} />;

--- a/src/components/onboarding/organisms/corporate/company-step/CompanyAddress.tsx
+++ b/src/components/onboarding/organisms/corporate/company-step/CompanyAddress.tsx
@@ -10,7 +10,7 @@ const ADDRESS_FIELDS = [
     {
         name: "registrationDate",
         label: "Date of Registration",
-        placeholder: "DD/MM/YYYY",
+        placeholder: "Sandbox example: 19/07/2024",
         type: "date",
         autoComplete: "bday"
     },

--- a/src/components/onboarding/organisms/corporate/company-step/CompanyDetails.tsx
+++ b/src/components/onboarding/organisms/corporate/company-step/CompanyDetails.tsx
@@ -17,7 +17,7 @@ const COMPANY_FIELDS = [
     {
         name: "companyName",
         label: "Company Legal Name",
-        placeholder: "Exactly as registered with CAC",
+        placeholder: "Sandbox example: JOHN DOE LIMITED",
         autoComplete: "organization"
     },
     {
@@ -43,7 +43,7 @@ const COMPANY_FIELDS = [
             {
                 name: "registrationNumber",
                 label: "Registration Number",
-                placeholder: "BN1234567",
+                placeholder: "Sandbox example: 1261103 or 14320749",
                 autoComplete: "off"
             }
         ]

--- a/src/components/onboarding/organisms/corporate/company-step/CompanyInformation.tsx
+++ b/src/components/onboarding/organisms/corporate/company-step/CompanyInformation.tsx
@@ -14,6 +14,7 @@ import { tokenStorage } from '@/lib/token-storage';
 import { showApiErrorToast } from '@/lib/error-feedback';
 import { useUserStore } from '@/store/userStore';
 import { mapApiUserTypeToStoreUserType } from '@/lib/user-type';
+import onboardingService from '@/services/onboardingService';
 
 const corporateHeaderLabels = [
     { id: 'details', title: 'Corporate Investment Account', desc: 'Register your organization to invest in vetted Nigerian startups' },
@@ -51,6 +52,53 @@ export function CompanyInformation() {
 
     const canProceedCurrent = validateSubStep(currentStep.id as CompanySubStepId, store);
 
+    const persistExistingAccountCompanyStep = async () => {
+        if (isFundraiser) {
+            await onboardingService.saveFundraiserCompany({
+                companyLegalName: store.formData.companyName,
+                tradingBrandName: store.formData.brandName || null,
+                registrationType: store.formData.registrationType,
+                registrationNumber: store.formData.registrationNumber,
+                companyLoginEmail: store.formData.loginEmail,
+                dateOfRegistration: store.formData.registrationDate || null,
+                companyWebsite: store.formData.companyWebsite || null,
+                businessAddress: store.formData.businessAddress || "",
+                registeredAddress: store.formData.registeredAddress || "",
+                companyEmail: store.formData.companyEmail || "",
+                companyPhone: store.formData.companyPhone || "",
+            });
+            return;
+        }
+
+        await onboardingService.saveCorporateCompany({
+            companyLegalName: store.formData.companyName,
+            tradingBrandName: store.formData.brandName,
+            registrationType: store.formData.registrationType,
+            registrationNumber: store.formData.registrationNumber,
+            companyLoginEmail: store.formData.loginEmail,
+        });
+
+        await onboardingService.saveCorporateAddress({
+            dateOfRegistration: store.formData.registrationDate || "",
+            companyWebsite: store.formData.companyWebsite || "",
+            businessAddress: store.formData.businessAddress || "",
+            registeredAddress: store.formData.registeredAddress || "",
+            companyEmail: store.formData.companyEmail || "",
+            companyPhone: store.formData.companyPhone || "",
+        });
+
+        await onboardingService.saveCorporateRepresentative({
+            representativeFullName: store.formData.repFullName,
+            representativeJobTitle: store.formData.repJobTitle,
+            representativePhoneNumber: store.formData.repPhoneNumber,
+            representativeDateOfBirth: store.formData.repDob,
+            representativeEmail: store.formData.repEmail,
+            representativeNationality: store.formData.repNationality,
+            representativeCountryOfResidence: store.formData.repResidence,
+            representativeAddress: store.formData.repAddress,
+        });
+    };
+
     const nextSubStep = async () => {
         // 1. Always validate the current view first
         if (!canProceedCurrent) {
@@ -74,10 +122,19 @@ export function CompanyInformation() {
 
             // Account already exists after email verification — keep edits and resume flow.
             if (store.emailVerified) {
-                const nextAfterEmail = isFundraiser
-                    ? "company-documentation"
-                    : "categorization";
-                router.push(`/onboarding/${investorUserType}/${nextAfterEmail}`);
+                setIsSubmitting(true);
+                try {
+                    await persistExistingAccountCompanyStep();
+                    const nextAfterEmail = isFundraiser
+                        ? "company-documentation"
+                        : "categorization";
+                    router.push(`/onboarding/${investorUserType}/${nextAfterEmail}`);
+                } catch (error) {
+                    showApiErrorToast(error, `Unable to save ${isFundraiser ? "fundraiser" : "corporate"} company details.`);
+                    setShowErrors(true);
+                } finally {
+                    setIsSubmitting(false);
+                }
                 return;
             }
 

--- a/src/components/onboarding/organisms/fundraiser/payment-application-fee/PaymentApplicationFee.tsx
+++ b/src/components/onboarding/organisms/fundraiser/payment-application-fee/PaymentApplicationFee.tsx
@@ -29,6 +29,7 @@ interface PaymentApplicationFeeProps {
     minInvestment?: number
     offeringId?: number
     offeringSlug?: string
+    onBack?: () => void
 }
 
 const FUNDRAISER_PAYMENT_STATE_KEY = "fundraiser_application_fee_state";
@@ -39,6 +40,7 @@ export function PaymentApplicationFee({
     unitPrice,
     minInvestment,
     offeringId,
+    onBack,
 }: PaymentApplicationFeeProps) {
 
     const pathName = usePathname()
@@ -247,6 +249,10 @@ export function PaymentApplicationFee({
         if (subStepIndex > 0) {
             setSubStepIndex(prev => prev - 1);
         } else {
+            if (onBack) {
+                onBack();
+                return;
+            }
             router.back();
         }
     };

--- a/src/components/settings/organisms/fundraiser/CompanyProfile.tsx
+++ b/src/components/settings/organisms/fundraiser/CompanyProfile.tsx
@@ -32,6 +32,35 @@ const EMPTY_FORM: CompanyFormState = {
   headquarters: '',
 };
 
+function formatDateLabel(value?: string | null) {
+  if (!value) return '—';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getCacStatusTone(status?: string | null) {
+  const normalized = status?.trim().toLowerCase();
+
+  if (normalized === 'active' || normalized === 'registered' || normalized === 'incorporated' || normalized === 'verified') {
+    return 'bg-[#ECFDF3] text-[#027A48] border-[#ABEFC6]';
+  }
+
+  if (normalized === 'bypassed') {
+    return 'bg-[#FFFAEB] text-[#B54708] border-[#FEDF89]';
+  }
+
+  return 'bg-[#F2F4F7] text-[#344054] border-[#D0D5DD]';
+}
+
 function mapProfileToForm(profile: FundraiserSettingsProfile): CompanyFormState {
   return {
     companyName: profile.companyName ?? '',
@@ -131,6 +160,7 @@ export function CompanyProfile({ onBack }: CompanyProfileProps) {
   const locationLabel = profile.locationLabel || 'Location not set';
   const avatarFallback = profile.companyAvatarFallback || 'FR';
   const completionPercentage = profile.completionPercentage ?? 0;
+  const cacStatusLabel = profile.cacVerificationStatus || 'Not verified';
 
   return (
     <div className="w-full font-sans space-y-6">
@@ -231,6 +261,40 @@ export function CompanyProfile({ onBack }: CompanyProfileProps) {
         </div>
 
         <div className="lg:col-span-4 space-y-4">
+          <div className="bg-white border border-[#F4F5F7] rounded-xl p-5 space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
+                CAC Verification
+              </h3>
+              <span className={`inline-flex items-center rounded-full border px-3 py-1 text-[12px] font-semibold ${getCacStatusTone(profile.cacVerificationStatus)}`}>
+                {cacStatusLabel}
+              </span>
+            </div>
+
+            <div className="space-y-3 text-[14px]">
+              <div className="flex items-start justify-between gap-4">
+                <span className="text-[#858585]">Verified company name</span>
+                <span className="text-right text-[#1B1B1B]">{profile.cacVerifiedCompanyName || '—'}</span>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <span className="text-[#858585]">Verified registration number</span>
+                <span className="text-right text-[#1B1B1B]">{profile.cacVerifiedRegistrationNumber || '—'}</span>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <span className="text-[#858585]">Company type</span>
+                <span className="text-right text-[#1B1B1B]">{profile.cacVerifiedCompanyType || '—'}</span>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <span className="text-[#858585]">Incorporation date</span>
+                <span className="text-right text-[#1B1B1B]">{formatDateLabel(profile.cacIncorporationDate)}</span>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <span className="text-[#858585]">Verified at</span>
+                <span className="text-right text-[#1B1B1B]">{formatDateLabel(profile.cacVerifiedAt)}</span>
+              </div>
+            </div>
+          </div>
+
           <div className="bg-white border border-[#F4F5F7] rounded-xl p-5 space-y-4">
             <h3 className="text-[16px] text-[#1B1B1B]" style={{ ...TYPOGRAPHY.body, fontWeight: 600 }}>
               Location

--- a/src/lib/onboarding-file-upload.ts
+++ b/src/lib/onboarding-file-upload.ts
@@ -39,7 +39,12 @@ export function hasOnboardingDocument(
   file: File | null | undefined,
   pathOrKey: string | null | undefined
 ): boolean {
-  return Boolean(pathOrKeyOrNull(pathOrKey) || (file instanceof File && file.size > 0));
+  const hasFileObject =
+    typeof File !== "undefined" &&
+    file instanceof File &&
+    file.size > 0;
+
+  return Boolean(pathOrKeyOrNull(pathOrKey) || hasFileObject);
 }
 
 export function displayNameFromPathOrKey(pathOrKey: string): string {

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -134,7 +134,7 @@ async function saveCorporateCompany(
   corporateCompanyPayload: NonNullable<SaveOnboardingRequest["corporateCompanyPayload"]>
 ): Promise<void> {
   await saveOnboarding({
-    step: "InvestmentProfile",
+    step: "InvestorCategory",
     investorCategoryPayload: null,
     investmentProfilePayload: null,
     kycPayload: null,
@@ -153,7 +153,7 @@ async function saveCorporateAddress(
   corporateAddressPayload: NonNullable<SaveOnboardingRequest["corporateAddressPayload"]>
 ): Promise<void> {
   await saveOnboarding({
-    step: "InvestmentProfile",
+    step: "InvestorCategory",
     investorCategoryPayload: null,
     investmentProfilePayload: null,
     kycPayload: null,
@@ -174,7 +174,7 @@ async function saveCorporateRepresentative(
   >
 ): Promise<void> {
   await saveOnboarding({
-    step: "InvestmentProfile",
+    step: "InvestorCategory",
     investorCategoryPayload: null,
     investmentProfilePayload: null,
     kycPayload: null,

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -97,6 +97,12 @@ export interface OnboardingCorporateProfileDto {
     registrationType?: string | null;
     registrationNumber?: string | null;
     companyLoginEmail?: string | null;
+    cacVerifiedCompanyName?: string | null;
+    cacVerifiedRegistrationNumber?: string | null;
+    cacVerifiedCompanyType?: string | null;
+    cacVerificationStatus?: string | null;
+    cacVerifiedAt?: string | null;
+    cacIncorporationDate?: string | null;
   } | null;
   address?: {
     dateOfRegistration?: string | null;
@@ -133,6 +139,12 @@ export interface OnboardingFundRaiserProfileDto {
     registeredAddress?: string | null;
     companyEmail?: string | null;
     companyPhone?: string | null;
+    cacVerifiedCompanyName?: string | null;
+    cacVerifiedRegistrationNumber?: string | null;
+    cacVerifiedCompanyType?: string | null;
+    cacVerificationStatus?: string | null;
+    cacVerifiedAt?: string | null;
+    cacIncorporationDate?: string | null;
   } | null;
   representative?: {
     representativeFullName?: string | null;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -61,6 +61,12 @@ export interface FundraiserSettingsContact {
 export interface FundraiserSettingsProfile {
   companyName: string | null;
   registrationNumber: string | null;
+  cacVerifiedCompanyName: string | null;
+  cacVerifiedRegistrationNumber: string | null;
+  cacVerifiedCompanyType: string | null;
+  cacVerificationStatus: string | null;
+  cacVerifiedAt: string | null;
+  cacIncorporationDate: string | null;
   bio: string | null;
   website: string | null;
   publicEmail: string | null;

--- a/src/types/user-api.ts
+++ b/src/types/user-api.ts
@@ -10,6 +10,12 @@ export interface UserCompanyProfile {
   registeredAddress?: string | null;
   companyEmail?: string | null;
   companyPhone?: string | null;
+  cacVerifiedCompanyName?: string | null;
+  cacVerifiedRegistrationNumber?: string | null;
+  cacVerifiedCompanyType?: string | null;
+  cacVerificationStatus?: string | null;
+  cacVerifiedAt?: string | null;
+  cacIncorporationDate?: string | null;
   representativeFullName?: string | null;
   representativeJobTitle?: string | null;
   representativePhoneNumber?: string | null;


### PR DESCRIPTION
## What changed
- updated corporate and fundraiser onboarding flow behavior around email verification, back navigation, deletion flow, review hydration, and payment-step navigation
- added CAC sandbox placeholders for company onboarding fields
- surfaced CAC verification status and details in fundraiser settings
- updated onboarding and user-facing API types to match the backend response shape

## Why
- testers needed clear sandbox values instead of guessing what Dojah would accept
- onboarding flow bugs were blocking navigation, submission, and account-deletion expectations
- fundraiser settings needed to reflect backend CAC verification state

## Impact
- testers now see Dojah sandbox examples directly in the shared company onboarding fields
- fundraiser settings now shows CAC verification status/details
- onboarding type contracts align with the updated API responses

## Root cause
- the frontend was missing guidance for Dojah sandbox inputs
- some onboarding views relied on stale or incomplete hydration and navigation behavior
- CAC verification metadata was not represented in the frontend model layer

## Validation
- `npm run type-check`
